### PR TITLE
Cross build

### DIFF
--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+on: [push, pull_request]
+
+name: Cross-compile
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - thumbv6m-none-eabi
+          - thumbv7m-none-eabi
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Build for target
+        run: cargo build --release --target=${{ matrix.target }}

--- a/demos/src/lib.rs
+++ b/demos/src/lib.rs
@@ -3,3 +3,5 @@
 //! Demos crate for picojson-rs
 //!
 //! This crate contains demonstration code and examples.
+
+#![cfg_attr(not(test), no_std)]


### PR DESCRIPTION
## Summary by Sourcery

Enable no_std in the demos crate for non-test builds and introduce a CI workflow to cross-compile embedded targets.

Enhancements:
- Enable no_std for the demos crate in non-test builds

CI:
- Add a GitHub Actions workflow to cross-compile release builds for thumbv6m-none-eabi and thumbv7m-none-eabi targets