### PR TITLE
Prep release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ Use `SliceParser` when the entire JSON document is in memory. A scratch buffer i
 use picojson::{SliceParser, Event, String};
 
 let json = r#"{"message": "Hello\nWorld"}"#;
-let mut scratch = [0u8; 1024];
+let mut scratch = [0u8; 32];
 let mut parser = SliceParser::with_buffer(json, &mut scratch);
 
 loop {
     match parser.next_event()? {
         Event::Key(key) => { // key is a picojson::String
-            println!("Key: {}", &*key);
+            println!("Key: {}", key);
         }
         Event::String(value) => {
-            println!("Value: {}", &*value);
+            println!("Value: {}", value);
         }
         Event::EndDocument => break,
         _ => {}

--- a/picojson/Cargo.toml
+++ b/picojson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picojson"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 exclude = ["/.github/**"]


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 0.1.2 release by bumping the version and refining the README example.

Build:
- Bump crate version to 0.1.2

Documentation:
- Reduce scratch buffer size and simplify print statements in README example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README example to use a smaller scratch buffer and simplified print statement formatting.

* **Chores**
  * Bumped the package version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->