### PR TITLE
Add panic checker tooling

### DIFF
--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install simavr and dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y simavr avarice gcc-avr avr-libc
+          sudo apt-get install -y simavr gcc-avr avr-libc
 
       - name: Install cargo-bloat
         run: cargo install cargo-bloat
@@ -46,6 +46,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
+
+      - name: Install simavr and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y simavr gcc-avr avr-libc
 
       - name: Install cargo-binutils
         run: cargo install cargo-binutils

--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install cargo-bloat
         run: cargo install cargo-bloat
+      - name: Install cargo-binutils
+        run: cargo install cargo-binutils
 
       - name: Run Stack Analysis
         working-directory: avr_demo
@@ -32,3 +34,22 @@ jobs:
       - name: Run Bloat Analysis
         working-directory: avr_demo
         run: python run_suite.py bloat
+
+  avr_panic_check:
+    name: AVR Panic Prevention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+
+      - name: Install cargo-binutils
+        run: cargo install cargo-binutils
+
+      - name: Run Panic Check (Minimal Example)
+        working-directory: avr_demo
+        run: python run_suite.py panic --example minimal

--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build the demos in panic check profile
         working-directory: avr_demo
-        run: cargo build --example --profile panic_checks minimal
+        run: cargo build --profile panic_checks --example minimal
 
       - name: Run Panic Check (Minimal Example)
         working-directory: avr_demo

--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -50,6 +50,18 @@ jobs:
       - name: Install cargo-binutils
         run: cargo install cargo-binutils
 
+      - name: Build the demos in Release mode
+        working-directory: avr_demo
+        run: cargo build --release --examples
+
+      - name: Build the demos in Dev mode
+        working-directory: avr_demo
+        run: cargo build --examples
+
+      - name: Build the demos in panic check profile
+        working-directory: avr_demo
+        run: cargo build --example --profile panic_checks minimal
+
       - name: Run Panic Check (Minimal Example)
         working-directory: avr_demo
         run: python run_suite.py panic --example minimal

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -23,6 +23,8 @@ features = ["arduino-uno"]
 
 [profile.dev]
 panic = "abort"
+lto = true
+opt-level = "s"
 
 # Build profile for investigating panics in the code
 # We don't want to optimize away any code, but do

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -24,7 +24,7 @@ features = ["arduino-uno"]
 [profile.dev]
 panic = "abort"
 
-# Build profile for investigatinc panics in the code
+# Build profile for investigating panics in the code
 # We don't want to optimize away any code, but do
 # enable dead code elimination.
 [profile.panic_checks]

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -30,14 +30,18 @@ panic = "abort"
 [profile.panic_checks]
 inherits = "dev"
 panic = "abort"
-opt-level = 1         # Mminimal code size optimizations, mostly just DCE
-lto = "fat"             # Make sure it's off unless you want fat LTO DCE
+opt-level = 1         # Minimal code size optimizations, mostly just DCE
+lto = "fat"           # Enable fat LTO for better dead code elimination
 codegen-units = 1       # helps DCE across units
 strip = "none"          # Keep symbols
 debug = "full"
 incremental = false
 overflow-checks = true  # Enable ( it's a default, but we want to be explicit )
-rustflags = ["-Z", "ub-checks=no"] # Disable builtin undefined behavior checks
+# Disable the compiler's built-in undefined behavior checks.
+# These checks can insert their own panic paths, creating noise in our analysis.
+# We are focused on panics from application logic (e.g., unwrap, bounds checks),
+# so disabling these helps narrow the focus. This is an unstable flag.
+rustflags = ["-Z", "ub-checks=no"]
 
 [profile.release]
 panic = "abort"

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -1,3 +1,6 @@
+# Profile specific rustflags for panic checking
+cargo-features = ["profile-rustflags"]
+
 [package]
 name = "avr_demo"
 version = "0.1.0"
@@ -9,7 +12,7 @@ autobenches = false
 [dependencies]
 picojson = { path = "../picojson", default-features = false, features = ["int32"]}
 panic-halt = "1.0"
-ufmt = "0.2"
+ufmt = { version = "0.2", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.6", default-features = false }
 
@@ -20,8 +23,21 @@ features = ["arduino-uno"]
 
 [profile.dev]
 panic = "abort"
-lto = true
-opt-level = "s"
+
+# Build profile for investigatinc panics in the code
+# We don't want to optimize away any code, but do
+# enable dead code elimination.
+[profile.panic_checks]
+inherits = "dev"
+panic = "abort"
+opt-level = 1         # Mminimal code size optimizations, mostly just DCE
+lto = "fat"             # Make sure it's off unless you want fat LTO DCE
+codegen-units = 1       # helps DCE across units
+strip = "none"          # Keep symbols
+debug = "full"
+incremental = false
+overflow-checks = true  # Enable ( it's a default, but we want to be explicit )
+rustflags = ["-Z", "ub-checks=no"] # Disable builtin undefined behavior checks
 
 [profile.release]
 panic = "abort"
@@ -31,7 +47,7 @@ lto = true
 opt-level = "s"
 
 [features]
-default = ["depth-7", "pico-tiny"]
+default = ["depth-7", "pico-tiny", "ufmt"]
 
 depth-7 = []
 depth-9 = []

--- a/avr_demo/examples/minimal.rs
+++ b/avr_demo/examples/minimal.rs
@@ -1,0 +1,12 @@
+#![feature(asm_experimental_arch)]
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    loop {
+        unsafe { core::arch::asm!("sleep") }
+    }
+}

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -331,7 +331,7 @@ def print_panic_report(results):
         print(f"| {example} | {result} |")
 
     # Overall status
-    failed_count = sum(bool("FAIL" in r)
+    failed_count = sum("FAIL" in r for r in results.values())
     total_count = len([r for r in results.values() if r != "Not Found"])
 
     if failed_count > 0:
@@ -340,6 +340,18 @@ def print_panic_report(results):
     else:
         print(f"\n✅ OVERALL: All {total_count} examples are panic-free!")
         return True
+
+def _print_panic_usage():
+    """Prints the usage instructions for the panic checker."""
+    available = get_available_examples()
+    print("Available examples for panic checking:")
+    for example in available:
+        print(f"  - {example}")
+    print("\nUsage:")
+    print("  python run_suite.py panic --example <name>                                    # Check specific example")
+    print("  python run_suite.py panic --example <name> --no-default-features             # Check without default features")
+    print("  python run_suite.py panic --example <name> --features depth-7,pico-tiny      # Check with specific features")
+    print("  python run_suite.py panic --examples                                          # Check all examples")
 
 def main():
     """Main entry point for the script."""
@@ -417,15 +429,7 @@ def main():
             sys.exit(0 if success else 1)
         else:
             # Show available examples and usage
-            available = get_available_examples()
-            print("Available examples for panic checking:")
-            for example in available:
-                print(f"  - {example}")
-            print(f"\nUsage:")
-            print(f"  python run_suite.py panic --example <name>                                    # Check specific example")
-            print(f"  python run_suite.py panic --example <name> --no-default-features             # Check without default features")
-            print(f"  python run_suite.py panic --example <name> --features depth-7,pico-tiny      # Check with specific features")
-            print(f"  python run_suite.py panic --examples                                          # Check all examples")
+            _print_panic_usage()
             sys.exit(0)
 
 if __name__ == "__main__":

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -287,7 +287,7 @@ def run_panic_analysis(specific_examples=None):
     examples = specific_examples or get_available_examples()
     results = {}
 
-    print(f"\n=== Panic Reference Analysis ===")
+    print("\n=== Panic Reference Analysis ===")
     print(f"Checking {len(examples)} example(s): {', '.join(examples)}")
 
     for example in examples:

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -290,20 +290,16 @@ def get_available_examples():
     examples_dir = "examples"
 
     if os.path.exists(examples_dir):
-        for file in os.listdir(examples_dir):
-            if file.endswith('.rs'):
-                example_name = file[:-3]  # Remove .rs extension
-                examples.append(example_name)
-
+        examples.extend(
+            file[:-3]
+            for file in os.listdir(examples_dir)
+            if file.endswith('.rs')
+        )
     return sorted(examples)
 
 def run_panic_analysis(specific_examples=None):
     """Run panic checker on specified examples or all available ones."""
-    if specific_examples:
-        examples = specific_examples
-    else:
-        examples = get_available_examples()
-
+    examples = specific_examples if specific_examples else get_available_examples()
     results = {}
 
     print(f"\n=== Panic Reference Analysis ===")
@@ -335,7 +331,7 @@ def print_panic_report(results):
         print(f"| {example} | {result} |")
 
     # Overall status
-    failed_count = sum(1 for r in results.values() if "FAIL" in r)
+    failed_count = sum(bool("FAIL" in r)
     total_count = len([r for r in results.values() if r != "Not Found"])
 
     if failed_count > 0:

--- a/avr_demo/rust-toolchain.toml
+++ b/avr_demo/rust-toolchain.toml
@@ -7,5 +7,6 @@ components = [
     "rustfmt",
     "rust-src",
     "rust-analyzer",
+    "llvm-tools"
 ]
 profile = "minimal"

--- a/picojson/src/ujson/tokenizer/mod.rs
+++ b/picojson/src/ujson/tokenizer/mod.rs
@@ -853,11 +853,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     b'}',
                 ) => {
                     if let Some((comma_char, _)) = self.context.after_comma {
-                        return Error::new(
-                            ErrKind::TrailingComma,
-                            comma_char,
-                            pos,
-                        );
+                        return Error::new(ErrKind::TrailingComma, comma_char, pos);
                     }
                     self.context.exit_object(pos)?;
                     callback(Event::ObjectEnd, pos);
@@ -881,7 +877,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     State::Object {
                         expect: Object::Key,
                     }
-                },
+                }
                 (
                     State::Object {
                         expect: Object::CommaOrEnd,


### PR DESCRIPTION
Part of #24 

## Summary by Sourcery

Add panic reference checking capabilities to the AVR demo suite, integrate into the CLI and GitHub Actions, and extend build configurations for focused panic detection.

New Features:
- Introduce a "panic" analysis command in run_suite.py to scan AVR example assemblies for panic patterns.
- Add auto-discovery of examples and panic report generation with both single-example and all-examples modes.
- Include a minimal no_std example for panic checking.

Enhancements:
- Define a dedicated panic_checks Cargo profile with custom rustflags for precise panic analysis.
- Make ufmt an optional dependency and include it in default features.
- Add llvm-tools to the AVR rust-toolchain configuration.

Build:
- Enable the profile-rustflags feature in Cargo.toml for panic_checks.
- Update default features to include ufmt.

CI:
- Install cargo-binutils in CI.
- Add a new "AVR Panic Prevention" GitHub Actions job that builds demos in multiple profiles and runs the panic checker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a panic analysis tool for AVR Rust examples, with CLI support for detailed panic checks and reporting.
  * Added a minimal example for AVR microcontrollers demonstrating sleep mode usage.
  * Added a new build profile for advanced panic investigation in AVR projects.

* **Chores**
  * Updated workflows to include new panic check jobs and additional tool installations.
  * Added llvm-tools to the Rust toolchain configuration.

* **Refactor**
  * Simplified error formatting in the JSON tokenizer for improved code readability.

* **Dependency Updates**
  * Made the ufmt dependency optional and included it in the default feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->