### PR TITLE
Fix nightly warnings about lifetimes

### DIFF
--- a/avr_demo/examples/test_picojson.rs
+++ b/avr_demo/examples/test_picojson.rs
@@ -87,13 +87,10 @@ fn parse_json<'b>(json_data: &[u8], scratch: &'b mut [u8]) -> Result<Doc<'b>, Pa
             None => break,
         }
     }
-    let status_str = match scratch
+    let status_str = scratch
         .get(..status_len)
         .and_then(|slice| core::str::from_utf8(slice).ok())
-    {
-        Some(s) => s,
-        None => "",
-    };
+        .unwrap_or("");
 
     Ok(Doc {
         id,

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -29,10 +29,10 @@ DEPTHS = get_depths_from_build_rs()
 # The test configurations to run.
 # (Test Name, Cargo Example Name, Extra Features)
 CONFIGS = [
-    ("serde", "test_serde", []),
-    ("picojson-tiny", "test_picojson", ["pico-tiny"]),
-    ("picojson-small", "test_picojson", ["pico-small"]),
-    ("picojson-huge", "test_picojson", ["pico-huge"]),
+    ("serde", "test_serde", ["ufmt"]),
+    ("picojson-tiny", "test_picojson", ["pico-tiny","ufmt"]),
+    ("picojson-small", "test_picojson", ["pico-small","ufmt"]),
+    ("picojson-huge", "test_picojson", ["pico-huge","ufmt"]),
 ]
 
 def run_stack_analysis():

--- a/picojson/src/copy_on_escape.rs
+++ b/picojson/src/copy_on_escape.rs
@@ -152,7 +152,7 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
     ///
     /// # Returns
     /// The final String (either borrowed or unescaped)
-    pub fn end_string(&mut self, pos: usize) -> Result<String, ParseError> {
+    pub fn end_string(&mut self, pos: usize) -> Result<String<'_, '_>, ParseError> {
         if self.using_scratch {
             // Copy final span from last_copied_pos to end
             self.copy_span_to_scratch(pos, 0)?;

--- a/picojson/src/number_parser.rs
+++ b/picojson/src/number_parser.rs
@@ -33,7 +33,7 @@ pub fn parse_number_event<T: NumberExtractor>(
     extractor: &T,
     start_pos: usize,
     from_container_end: bool,
-) -> Result<Event, ParseError> {
+) -> Result<Event<'_, '_>, ParseError> {
     let current_pos = extractor.current_position();
 
     // Determine if we should exclude a delimiter from the number

--- a/picojson/src/shared.rs
+++ b/picojson/src/shared.rs
@@ -106,7 +106,7 @@ pub trait PullParser {
     /// Iterator-like method that returns None when parsing is complete.
     /// This method returns None when EndDocument is reached, Some(Ok(event)) for successful events,
     /// and Some(Err(error)) for parsing errors.
-    fn next(&mut self) -> Option<Result<Event, ParseError>> {
+    fn next(&mut self) -> Option<Result<Event<'_, '_>, ParseError>> {
         match self.next_event() {
             Ok(Event::EndDocument) => None,
             other => Some(other),
@@ -114,7 +114,7 @@ pub trait PullParser {
     }
     /// Returns the next JSON event or an error if parsing fails.
     /// Parsing continues until `EndDocument` is returned or an error occurs.
-    fn next_event(&mut self) -> Result<Event, ParseError>;
+    fn next_event(&mut self) -> Result<Event<'_, '_>, ParseError>;
 }
 
 /// Utility for calculating common content range boundaries in JSON parsing.

--- a/picojson/src/slice_parser.rs
+++ b/picojson/src/slice_parser.rs
@@ -175,7 +175,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
         &mut self,
         start: usize,
         from_container_end: bool,
-    ) -> Result<Event, ParseError> {
+    ) -> Result<Event<'_, '_>, ParseError> {
         crate::number_parser::parse_number_event(&self.buffer, start, from_container_end)
     }
 
@@ -184,7 +184,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
     fn handle_simple_escape_token(
         &mut self,
         escape_token: &EventToken,
-    ) -> Result<Option<Event>, ParseError> {
+    ) -> Result<Option<Event<'_, '_>>, ParseError> {
         // Use unified escape token processing
         let unescaped_char = EscapeProcessor::process_escape_token(escape_token)?;
 
@@ -193,7 +193,10 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
     }
 
     /// Handles escape sequence events by delegating to CopyOnEscape if we're inside a string or key
-    fn handle_escape_event(&mut self, escape_char: u8) -> Result<Option<Event>, ParseError> {
+    fn handle_escape_event(
+        &mut self,
+        escape_char: u8,
+    ) -> Result<Option<Event<'_, '_>>, ParseError> {
         if let State::String(_) | State::Key(_) = self.parser_state.state {
             self.copy_on_escape
                 .handle_escape(self.buffer.current_pos(), escape_char)?;
@@ -254,7 +257,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
 
     /// Returns the next JSON event or an error if parsing fails.
     /// Parsing continues until `EndDocument` is returned or an error occurs.
-    fn next_event_impl(&mut self) -> Result<Event, ParseError> {
+    fn next_event_impl(&mut self) -> Result<Event<'_, '_>, ParseError> {
         if self.buffer.is_past_end() {
             return Ok(Event::EndDocument);
         }
@@ -443,7 +446,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
 }
 
 impl<'a, 'b, C: BitStackConfig> PullParser for SliceParser<'a, 'b, C> {
-    fn next_event(&mut self) -> Result<Event, ParseError> {
+    fn next_event(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.next_event_impl()
     }
 }

--- a/picojson/src/stream_parser.rs
+++ b/picojson/src/stream_parser.rs
@@ -124,7 +124,7 @@ impl<'b, R: Reader, C: BitStackConfig> StreamParser<'b, R, C> {
 /// Shared methods for StreamParser with any BitStackConfig
 impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     /// Get the next JSON event from the stream
-    fn next_event_impl(&mut self) -> Result<Event, ParseError> {
+    fn next_event_impl(&mut self) -> Result<Event<'_, '_>, ParseError> {
         // Apply any queued unescaped content reset from previous call
         self.apply_unescaped_reset_if_queued();
 
@@ -321,12 +321,12 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Extract number from parser state without 'static lifetime cheating
-    fn extract_number_from_state(&mut self) -> Result<Event, ParseError> {
+    fn extract_number_from_state(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.extract_number_from_state_with_context(false)
     }
 
     /// Extract string after all buffer operations are complete
-    fn extract_string_from_state(&mut self) -> Result<Event, ParseError> {
+    fn extract_string_from_state(&mut self) -> Result<Event<'_, '_>, ParseError> {
         let crate::shared::State::String(start_pos) = self.parser_state.state else {
             return Err(ParserErrorHandler::state_mismatch("string", "extract"));
         };
@@ -341,7 +341,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Helper to create an unescaped string from DirectBuffer
-    fn create_unescaped_string(&mut self) -> Result<Event, ParseError> {
+    fn create_unescaped_string(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.queue_unescaped_reset();
         let unescaped_slice = self.direct_buffer.get_unescaped_slice()?;
         let str_content = ParserErrorHandler::bytes_to_utf8_str(unescaped_slice)?;
@@ -349,7 +349,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Helper to create a borrowed string from DirectBuffer
-    fn create_borrowed_string(&mut self, start_pos: usize) -> Result<Event, ParseError> {
+    fn create_borrowed_string(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
         let current_pos = self.direct_buffer.current_position();
         let (content_start, content_end) =
             ContentRange::string_content_bounds(start_pos, current_pos);
@@ -362,7 +362,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Extract key after all buffer operations are complete
-    fn extract_key_from_state(&mut self) -> Result<Event, ParseError> {
+    fn extract_key_from_state(&mut self) -> Result<Event<'_, '_>, ParseError> {
         let crate::shared::State::Key(start_pos) = self.parser_state.state else {
             return Err(ParserErrorHandler::state_mismatch("key", "extract"));
         };
@@ -377,7 +377,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Helper to create an unescaped key from DirectBuffer
-    fn create_unescaped_key(&mut self) -> Result<Event, ParseError> {
+    fn create_unescaped_key(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.queue_unescaped_reset();
         let unescaped_slice = self.direct_buffer.get_unescaped_slice()?;
         let str_content = ParserErrorHandler::bytes_to_utf8_str(unescaped_slice)?;
@@ -385,7 +385,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     }
 
     /// Helper to create a borrowed key from DirectBuffer
-    fn create_borrowed_key(&mut self, start_pos: usize) -> Result<Event, ParseError> {
+    fn create_borrowed_key(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
         let current_pos = self.direct_buffer.current_position();
         let (content_start, content_end) =
             ContentRange::string_content_bounds(start_pos, current_pos);
@@ -401,7 +401,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     fn extract_number_from_state_with_context(
         &mut self,
         from_container_end: bool,
-    ) -> Result<Event, ParseError> {
+    ) -> Result<Event<'_, '_>, ParseError> {
         let crate::shared::State::Number(start_pos) = self.parser_state.state else {
             return Err(ParserErrorHandler::state_mismatch("number", "extract"));
         };
@@ -596,7 +596,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
 }
 
 impl<'b, R: Reader, C: BitStackConfig> PullParser for StreamParser<'b, R, C> {
-    fn next_event(&mut self) -> Result<Event, ParseError> {
+    fn next_event(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.next_event_impl()
     }
 }


### PR DESCRIPTION
Also allow optional no-fmt compilation of demos

## Summary by Sourcery

Enable building demos without the ufmt feature, fix nightly compiler warnings by parameterizing parser events with explicit lifetimes, and improve demo JSON status handling.

New Features:
- Allow demos to compile without the ufmt feature by stubbing the uwriteln! macro and conditionally initializing serial.

Bug Fixes:
- Add explicit lifetimes to picojson parser methods and PullParser trait to address nightly compiler warnings.

Enhancements:
- Use safe slice.get_mut and UTF-8 conversion for status parsing in demos and include status output in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug output for parsed status strings after JSON parsing in demo examples.

* **Bug Fixes**
  * Improved safety when handling and extracting strings from parsed JSON, reducing the risk of panics.

* **Refactor**
  * Updated several method and trait signatures to include explicit lifetime annotations for improved type safety and correctness.
  * Made serial interface initialization and macro imports conditional based on feature flags for better flexibility.
  * Included the "ufmt" feature in all test configurations to standardize testing environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->