### PR TITLE
Panic free for SliceParser

### DIFF
--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -36,8 +36,15 @@ jobs:
         run: python run_suite.py bloat
 
   avr_panic_check:
-    name: AVR Panic Prevention
+    name: AVR Panic Prevention (${{ matrix.int_type }}, ${{ matrix.pico_size }}, ${{ matrix.profile }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [test_picojson]
+        int_type: [int8, int32]
+        profile: [release, dev]
+        pico_size: [pico-tiny, pico-huge]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -55,18 +62,14 @@ jobs:
       - name: Install cargo-binutils
         run: cargo install cargo-binutils
 
-      - name: Build the demos in Release mode
+      - name: Build the demos in ${{ matrix.profile }} mode
         working-directory: avr_demo
-        run: cargo build --release --examples
+        run: cargo build --example ${{ matrix.example }} --profile ${{ matrix.profile }} --no-default-features --features "${{ matrix.int_type }},${{ matrix.pico_size }}"
 
-      - name: Build the demos in Dev mode
+      - name: Check for panics ( minimal )
         working-directory: avr_demo
-        run: cargo build --examples
+        run: cargo nm    --example minimal               --profile ${{ matrix.profile }} --no-default-features --features "${{ matrix.int_type }},${{ matrix.pico_size }}" | ( ! egrep "panic|unwind" )
 
-      - name: Build the demos in panic check profile
+      - name: Check for panics
         working-directory: avr_demo
-        run: cargo build --profile panic_checks --example minimal
-
-      - name: Run Panic Check (Minimal Example)
-        working-directory: avr_demo
-        run: python run_suite.py panic --example minimal
+        run: cargo nm    --example ${{ matrix.example }} --profile ${{ matrix.profile }} --no-default-features --features "${{ matrix.int_type }},${{ matrix.pico_size }}" | ( ! egrep "panic|unwind" )

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Run cargo check
         run: cargo check
-      - name: Run cargo check --no-default-features
-        run: cargo check --no-default-features
 
   test:
     name: Tests
@@ -31,9 +29,15 @@ jobs:
           - name: Default (int64 + float)
             features: ""
 
-          # No features baseline
-          - name: No features
-            features: --no-default-features
+          # int8 configurations
+          - name: int8 + float
+            features: --no-default-features --features "int8,float"
+          - name: int8 + float-skip
+            features: --no-default-features --features "int8,float-skip"
+          - name: int8 + float-error
+            features: --no-default-features --features "int8,float-error"
+          - name: int8 + float-truncate
+            features: --no-default-features --features "int8,float-truncate"
 
           # int32 configurations
           - name: int32 + float

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,27 @@ repos:
         language: system
         pass_filenames: false
 
-    -   id: feature-matrix-no-defaults
-        name: Feature Matrix Check - No Defaults
-        entry: cargo check --manifest-path=picojson/Cargo.toml --no-default-features
+    -   id: feature-matrix-int8-float
+        name: Feature Matrix Check - int8 + float
+        entry: cargo check --manifest-path=picojson/Cargo.toml --no-default-features --features "int8,float"
+        language: system
+        pass_filenames: false
+
+    -   id: feature-matrix-int8-float-skip
+        name: Feature Matrix Check - int8 + float-skip
+        entry: cargo check --manifest-path=picojson/Cargo.toml --no-default-features --features "int8,float-skip"
+        language: system
+        pass_filenames: false
+
+    -   id: feature-matrix-int8-float-error
+        name: Feature Matrix Check - int8 + float-error
+        entry: cargo check --manifest-path=picojson/Cargo.toml --no-default-features --features "int8,float-error"
+        language: system
+        pass_filenames: false
+
+    -   id: feature-matrix-int8-float-truncate
+        name: Feature Matrix Check - int8 + float-truncate
+        entry: cargo check --manifest-path=picojson/Cargo.toml --no-default-features --features "int8,float-truncate"
         language: system
         pass_filenames: false
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 ## TODO list
 - [ ] Constify what's possible
 - [ ] Remove `.unwrap()` calls
+- [ ] Remove copy_from_slice - can panic
 - [ ] Remove all bounds checked slice indexing that could panic!
 - [ ] Verify we are fully panic! free
 - [ ] Remove unnecessary `'static` lifetimes

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -10,8 +10,7 @@ autotests = false
 autobenches = false
 
 [dependencies]
-picojson = { path = "../picojson", default-features = false, features = ["int32"]}
-panic-halt = "1.0"
+picojson = { path = "../picojson", default-features = false}
 ufmt = { version = "0.2", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.6", default-features = false }
@@ -23,22 +22,11 @@ features = ["arduino-uno"]
 
 [profile.dev]
 panic = "abort"
-lto = true
-opt-level = "s"
-
-# Build profile for investigating panics in the code
-# We don't want to optimize away any code, but do
-# enable dead code elimination.
-[profile.panic_checks]
-inherits = "dev"
-panic = "abort"
-opt-level = 1         # Minimal code size optimizations, mostly just DCE
-lto = "fat"           # Enable fat LTO for better dead code elimination
+lto = "fat"
+opt-level = "z"         # Least amount of panic generation
 codegen-units = 1       # helps DCE across units
 strip = "none"          # Keep symbols
 debug = "full"
-incremental = false
-overflow-checks = true  # Enable ( it's a default, but we want to be explicit )
 # Disable the compiler's built-in undefined behavior checks.
 # These checks can insert their own panic paths, creating noise in our analysis.
 # We are focused on panics from application logic (e.g., unwrap, bounds checks),
@@ -53,7 +41,10 @@ lto = true
 opt-level = "s"
 
 [features]
-default = ["depth-7", "pico-tiny", "ufmt"]
+default = ["depth-7", "pico-tiny", "ufmt", "int8"]
+
+int8 = [ "picojson/int8"]
+int32 = [ "picojson/int32"]
 
 depth-7 = []
 depth-9 = []
@@ -70,8 +61,7 @@ depth-513 = []
 depth-1023 = []
 depth-1025 = []
 
-debug-trace = []
-
 pico-small = []
 pico-huge = []
 pico-tiny = []
+unsafe-utf8 = ["picojson/unsafe-utf8"]

--- a/avr_demo/examples/blinky.rs
+++ b/avr_demo/examples/blinky.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use panic_halt as _;
+use avr_demo as _;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/avr_demo/examples/minimal.rs
+++ b/avr_demo/examples/minimal.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #![no_main]
 
-use panic_halt as _;
+use avr_demo as _;
 
 #[arduino_hal::entry]
 fn main() -> ! {

--- a/avr_demo/examples/test_picojson.rs
+++ b/avr_demo/examples/test_picojson.rs
@@ -2,8 +2,8 @@
 #![no_std]
 #![no_main]
 
+use avr_demo as _;
 use avr_demo::stack_measurement::*;
-use panic_halt as _;
 use picojson::{self, Event, ParseError, PullParser, SliceParser};
 
 #[allow(unused_imports)]

--- a/avr_demo/examples/test_serde.rs
+++ b/avr_demo/examples/test_serde.rs
@@ -2,8 +2,8 @@
 #![no_std]
 #![no_main]
 
+use avr_demo as _;
 use avr_demo::stack_measurement::*;
-use panic_halt as _;
 use serde::Deserialize;
 
 // Conditional import of uwriteln! - stub out if ufmt feature is not enabled

--- a/avr_demo/src/lib.rs
+++ b/avr_demo/src/lib.rs
@@ -1,3 +1,14 @@
 #![no_std]
 
 pub mod stack_measurement;
+
+// Panic handler - registered automatically when crate is imported
+#[inline(never)]
+fn inner_panic_handler() -> ! {
+    loop {}
+}
+
+#[panic_handler]
+pub fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    inner_panic_handler();
+}

--- a/picojson/Cargo.toml
+++ b/picojson/Cargo.toml
@@ -24,6 +24,7 @@ default = ["int64", "float"]     # Default to full support: 64-bit integers and 
 float = []              # Enable f64 parsing support
 
 # Integer width options (mutually exclusive)
+int8  = []              # Use i8 for integers (8-bit)
 int32 = []              # Use i32 for integers (embedded-friendly)
 int64 = []              # Use i64 for integers (full range)
 
@@ -31,6 +32,8 @@ int64 = []              # Use i64 for integers (full range)
 float-skip = []         # Skip float values during parsing (continue with next token)
 float-error = []        # Error when encountering floats
 float-truncate = []     # Truncate floats to integers (1.7 → 1)
+# Use from_utf8_unchecked to avoid panic dependencies
+unsafe-utf8 = []
 defmt = ["dep:defmt"]
 
 [dependencies]

--- a/picojson/examples/no_float_demo.rs
+++ b/picojson/examples/no_float_demo.rs
@@ -23,7 +23,7 @@ fn main() {
     // Show configuration being used
     #[cfg(feature = "int32")]
     println!("Configuration: Using i32 integers (embedded-friendly)");
-    #[cfg(not(feature = "int32"))]
+    #[cfg(feature = "int64")]
     println!("Configuration: Using i64 integers (full range)");
 
     #[cfg(feature = "float")]
@@ -144,7 +144,7 @@ fn print_summary() {
     println!("\n=== Summary ===");
     #[cfg(feature = "int32")]
     println!("- Using i32 integers (no 64-bit math routines needed)");
-    #[cfg(not(feature = "int32"))]
+    #[cfg(feature = "int64")]
     println!("- Using i64 integers (full range)");
 
     #[cfg(feature = "float")]

--- a/picojson/src/config_check.rs
+++ b/picojson/src/config_check.rs
@@ -6,9 +6,24 @@
 //! features are not enabled simultaneously.
 
 // Compile-time checks for mutually exclusive integer width features
+
+// If none were selected that's an error
+#[cfg(not(any(feature = "int32", feature = "int64", feature = "int8")))]
+compile_error!("No integer width features selected: choose one of 'int32', 'int64', or 'int8'");
+
 #[cfg(all(feature = "int32", feature = "int64"))]
 compile_error!(
     "Cannot enable both 'int32' and 'int64' features simultaneously: choose one integer width"
+);
+
+#[cfg(all(feature = "int32", feature = "int8"))]
+compile_error!(
+    "Cannot enable both 'int32' and 'int8' features simultaneously: choose one integer width"
+);
+
+#[cfg(all(feature = "int64", feature = "int8"))]
+compile_error!(
+    "Cannot enable both 'int64' and 'int8' features simultaneously: choose one integer width"
 );
 
 // Compile-time checks for mutually exclusive float behavior features

--- a/picojson/src/copy_on_escape.rs
+++ b/picojson/src/copy_on_escape.rs
@@ -67,12 +67,21 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
     /// * `extra_space` - Additional space needed beyond the span (e.g., for escape character)
     fn copy_span_to_scratch(&mut self, end: usize, extra_space: usize) -> Result<(), ParseError> {
         if end > self.last_copied_pos {
-            let span = &self.input[self.last_copied_pos..end];
-            if self.scratch_pos + span.len() + extra_space > self.scratch.len() {
+            let span = self
+                .input
+                .get(self.last_copied_pos..end)
+                .ok_or(ParseError::UnexpectedState("Invalid span"))?;
+            let end_pos = self.scratch_pos.wrapping_add(span.len());
+            if end_pos.wrapping_add(extra_space) > self.scratch.len() {
                 return Err(ParseError::ScratchBufferFull);
             }
-            self.scratch[self.scratch_pos..self.scratch_pos + span.len()].copy_from_slice(span);
-            self.scratch_pos += span.len();
+            // Use zip to avoid copy_from_slice panic checks
+            if let Some(scratch_slice) = self.scratch.get_mut(self.scratch_pos..end_pos) {
+                for (dst, &src) in scratch_slice.iter_mut().zip(span.iter()) {
+                    *dst = src;
+                }
+            }
+            self.scratch_pos = self.scratch_pos.saturating_add(span.len());
         }
         Ok(())
     }
@@ -100,8 +109,10 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
         if self.scratch_pos >= self.scratch.len() {
             return Err(ParseError::ScratchBufferFull);
         }
-        self.scratch[self.scratch_pos] = unescaped_char;
-        self.scratch_pos += 1;
+        if let Some(slot) = self.scratch.get_mut(self.scratch_pos) {
+            *slot = unescaped_char;
+        }
+        self.scratch_pos = self.scratch_pos.saturating_add(1);
 
         // Update last copied position to after the escape sequence
         self.last_copied_pos = pos;
@@ -131,15 +142,20 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
         self.copy_span_to_scratch(start_pos, utf8_bytes.len())?;
 
         // Write the UTF-8 encoded bytes
-        if self.scratch_pos + utf8_bytes.len() > self.scratch.len() {
+        let new_scratch_pos = self.scratch_pos.wrapping_add(utf8_bytes.len());
+        if new_scratch_pos > self.scratch.len() {
             return Err(ParseError::ScratchBufferFull);
         }
-        self.scratch[self.scratch_pos..self.scratch_pos + utf8_bytes.len()]
-            .copy_from_slice(utf8_bytes);
-        self.scratch_pos += utf8_bytes.len();
+        // Use zip to avoid copy_from_slice panic checks
+        if let Some(scratch_slice) = self.scratch.get_mut(self.scratch_pos..new_scratch_pos) {
+            for (dst, &src) in scratch_slice.iter_mut().zip(utf8_bytes.iter()) {
+                *dst = src;
+            }
+        }
+        self.scratch_pos = self.scratch_pos.saturating_add(utf8_bytes.len());
 
         // Update last copied position to after the 6-byte Unicode escape sequence
-        self.last_copied_pos = start_pos + 6; // \uXXXX is always 6 bytes
+        self.last_copied_pos = start_pos.saturating_add(6); // \uXXXX is always 6 bytes
 
         Ok(())
     }
@@ -160,15 +176,19 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
             self.global_scratch_pos = self.scratch_pos;
 
             // Return unescaped string from scratch buffer
-            let unescaped_slice = &self.scratch[self.scratch_start..self.scratch_pos];
-            let unescaped_str =
-                core::str::from_utf8(unescaped_slice).map_err(ParseError::InvalidUtf8)?;
+            let unescaped_slice = self
+                .scratch
+                .get(self.scratch_start..self.scratch_pos)
+                .ok_or(ParseError::UnexpectedState("Invalid scratch slice"))?;
+            let unescaped_str = crate::shared::from_utf8(unescaped_slice)?;
             Ok(String::Unescaped(unescaped_str))
         } else {
             // No escapes found - return borrowed slice (zero-copy!)
-            let borrowed_bytes = &self.input[self.string_start..pos];
-            let borrowed_str =
-                core::str::from_utf8(borrowed_bytes).map_err(ParseError::InvalidUtf8)?;
+            let borrowed_bytes = self
+                .input
+                .get(self.string_start..pos)
+                .ok_or(ParseError::UnexpectedState("Invalid input slice"))?;
+            let borrowed_str = crate::shared::from_utf8(borrowed_bytes)?;
             Ok(String::Borrowed(borrowed_str))
         }
     }

--- a/picojson/src/escape_processor.rs
+++ b/picojson/src/escape_processor.rs
@@ -175,9 +175,10 @@ impl UnicodeEscapeCollector {
             ));
         }
 
-        // Safe assignment using get_mut
         if let Some(slot) = self.hex_buffer.get_mut(self.hex_pos) {
             *slot = digit;
+        } else {
+            return Err(ParseError::InvalidUnicodeHex);
         }
 
         self.hex_pos = self.hex_pos.saturating_add(1);

--- a/picojson/src/int_parser.rs
+++ b/picojson/src/int_parser.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Int parser module, mostly borrowed from core::num::parse::radix
+
+/// A custom error type for const integer parsing.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ConstParseIntegerError {
+    /// The input byte slice was empty.
+    Empty,
+    /// The input consisted only of a sign character (`+` or `-`).
+    SignOnly,
+    /// An invalid character was found that was not a base-10 digit.
+    InvalidDigit,
+    /// The number overflowed or underflowed the target integer type.
+    Overflow,
+}
+
+/// Creates a panic-free, const-stable, base-10 parser for a specific signed integer type.
+macro_rules! define_const_parser {
+    ($fn_name:ident, $int_ty:ty) => {
+        /// Parses a byte slice into a(n) `
+        #[doc = stringify!($int_ty)]
+        /// ` in a `const` context.
+        ///
+        /// This function is guaranteed not to panic.
+        pub const fn $fn_name(src: &[u8]) -> Result<$int_ty, ConstParseIntegerError> {
+            // Use pattern matching to safely handle the sign and avoid panics.
+            let (is_negative, mut digits) = match src {
+                [] => return Err(ConstParseIntegerError::Empty),
+                [b'+', rest @ ..] => (false, rest),
+                [b'-', rest @ ..] => (true, rest),
+                _ => (false, src),
+            };
+
+            if digits.is_empty() {
+                return Err(ConstParseIntegerError::SignOnly);
+            }
+
+            let mut result: $int_ty = 0;
+
+            // Use `while let` with `split_first` for safe, panic-free iteration.
+            while let Some((&byte, rest)) = digits.split_first() {
+                // Convert byte to digit.
+                let digit = match byte {
+                    b'0'..=b'9' => (byte - b'0') as $int_ty,
+                    // Not a digit, so it's an invalid character.
+                    _ => return Err(ConstParseIntegerError::InvalidDigit),
+                };
+
+                // Perform checked multiplication.
+                result = match result.checked_mul(10) {
+                    Some(val) => val,
+                    None => return Err(ConstParseIntegerError::Overflow),
+                };
+
+                // Perform checked addition or subtraction.
+                // Building the number negatively from the start correctly handles iT::MIN.
+                if is_negative {
+                    result = match result.checked_sub(digit) {
+                        Some(val) => val,
+                        None => return Err(ConstParseIntegerError::Overflow),
+                    }
+                } else {
+                    result = match result.checked_add(digit) {
+                        Some(val) => val,
+                        None => return Err(ConstParseIntegerError::Overflow),
+                    }
+                }
+
+                digits = rest;
+            }
+
+            Ok(result)
+        }
+    };
+}
+
+// Generate the functions using the macro.
+#[cfg(feature = "int8")]
+define_const_parser!(from_ascii_i8, i8);
+#[cfg(feature = "int32")]
+define_const_parser!(from_ascii_i32, i32);
+#[cfg(feature = "int64")]
+define_const_parser!(from_ascii_i64, i64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Tests for from_ascii_i8 ---
+    #[cfg(feature = "int8")]
+    mod test_i8 {
+        use super::*;
+        #[test]
+        fn test_from_ascii_i8_simple() {
+            assert_eq!(from_ascii_i8(b"0"), Ok(0));
+            assert_eq!(from_ascii_i8(b"42"), Ok(42));
+            assert_eq!(from_ascii_i8(b"-42"), Ok(-42));
+            assert_eq!(from_ascii_i8(b"+42"), Ok(42));
+        }
+
+        #[test]
+        fn test_from_ascii_i8_limits() {
+            assert_eq!(from_ascii_i8(b"127"), Ok(i8::MAX));
+            assert_eq!(from_ascii_i8(b"-128"), Ok(i8::MIN));
+        }
+
+        #[test]
+        fn test_from_ascii_i8_overflow() {
+            assert_eq!(from_ascii_i8(b"128"), Err(ConstParseIntegerError::Overflow));
+            assert_eq!(
+                from_ascii_i8(b"-129"),
+                Err(ConstParseIntegerError::Overflow)
+            );
+        }
+
+        #[test]
+        fn test_from_ascii_i8_errors() {
+            assert_eq!(from_ascii_i8(b""), Err(ConstParseIntegerError::Empty));
+            assert_eq!(from_ascii_i8(b"-"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(from_ascii_i8(b"+"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(
+                from_ascii_i8(b"12a"),
+                Err(ConstParseIntegerError::InvalidDigit)
+            );
+            assert_eq!(
+                from_ascii_i8(b"a12"),
+                Err(ConstParseIntegerError::InvalidDigit)
+            );
+            assert_eq!(
+                from_ascii_i8(b"1-2"),
+                Err(ConstParseIntegerError::InvalidDigit)
+            );
+        }
+    }
+
+    // --- Tests for from_ascii_i32 ---
+    #[cfg(feature = "int32")]
+    mod test_i32 {
+        use super::*;
+        #[test]
+        fn test_from_ascii_i32_simple() {
+            assert_eq!(from_ascii_i32(b"0"), Ok(0));
+            assert_eq!(from_ascii_i32(b"12345"), Ok(12345));
+            assert_eq!(from_ascii_i32(b"-12345"), Ok(-12345));
+            assert_eq!(from_ascii_i32(b"+12345"), Ok(12345));
+        }
+
+        #[test]
+        fn test_from_ascii_i32_limits() {
+            assert_eq!(
+                from_ascii_i32(i32::MAX.to_string().as_bytes()),
+                Ok(i32::MAX)
+            );
+            assert_eq!(
+                from_ascii_i32(i32::MIN.to_string().as_bytes()),
+                Ok(i32::MIN)
+            );
+        }
+
+        #[test]
+        fn test_from_ascii_i32_overflow() {
+            assert_eq!(
+                from_ascii_i32(b"2147483648"),
+                Err(ConstParseIntegerError::Overflow)
+            );
+            assert_eq!(
+                from_ascii_i32(b"-2147483649"),
+                Err(ConstParseIntegerError::Overflow)
+            );
+        }
+
+        #[test]
+        fn test_from_ascii_i32_errors() {
+            assert_eq!(from_ascii_i32(b""), Err(ConstParseIntegerError::Empty));
+            assert_eq!(from_ascii_i32(b"-"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(from_ascii_i32(b"+"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(
+                from_ascii_i32(b"123a45"),
+                Err(ConstParseIntegerError::InvalidDigit)
+            );
+        }
+    }
+
+    // --- Tests for from_ascii_i64 ---
+    #[cfg(feature = "int64")]
+    mod test_i64 {
+        use super::*;
+        #[test]
+        fn test_from_ascii_i64_simple() {
+            assert_eq!(from_ascii_i64(b"0"), Ok(0));
+            assert_eq!(from_ascii_i64(b"1234567890"), Ok(1234567890));
+            assert_eq!(from_ascii_i64(b"-1234567890"), Ok(-1234567890));
+            assert_eq!(from_ascii_i64(b"+1234567890"), Ok(1234567890));
+        }
+
+        #[test]
+        fn test_from_ascii_i64_limits() {
+            assert_eq!(
+                from_ascii_i64(i64::MAX.to_string().as_bytes()),
+                Ok(i64::MAX)
+            );
+            assert_eq!(
+                from_ascii_i64(i64::MIN.to_string().as_bytes()),
+                Ok(i64::MIN)
+            );
+        }
+
+        #[test]
+        fn test_from_ascii_i64_overflow() {
+            assert_eq!(
+                from_ascii_i64(b"9223372036854775808"),
+                Err(ConstParseIntegerError::Overflow)
+            );
+            assert_eq!(
+                from_ascii_i64(b"-9223372036854775809"),
+                Err(ConstParseIntegerError::Overflow)
+            );
+        }
+
+        #[test]
+        fn test_from_ascii_i64_errors() {
+            assert_eq!(from_ascii_i64(b""), Err(ConstParseIntegerError::Empty));
+            assert_eq!(from_ascii_i64(b"-"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(from_ascii_i64(b"+"), Err(ConstParseIntegerError::SignOnly));
+            assert_eq!(
+                from_ascii_i64(b"123a4567890"),
+                Err(ConstParseIntegerError::InvalidDigit)
+            );
+        }
+    }
+}

--- a/picojson/src/json_number.rs
+++ b/picojson/src/json_number.rs
@@ -157,7 +157,6 @@ impl core::fmt::Display for JsonNumber<'_, '_> {
 
 /// Detects if a number byte slice represents an integer (no decimal point or exponent).
 /// JSON numbers are pure ASCII, so this avoids unnecessary UTF-8 string processing.
-#[inline(never)]
 pub fn is_integer(bytes: &[u8]) -> bool {
     for &b in bytes {
         if b == b'.' || b == b'e' || b == b'E' {
@@ -169,7 +168,6 @@ pub fn is_integer(bytes: &[u8]) -> bool {
 
 /// Parses an integer byte slice into NumberResult using configured integer type.
 /// JSON numbers are pure ASCII, so this avoids unnecessary UTF-8 string processing.
-#[inline(never)]
 pub const fn parse_integer(bytes: &[u8]) -> NumberResult {
     #[cfg(feature = "int8")]
     let result = from_ascii_i8(bytes);
@@ -187,7 +185,6 @@ pub const fn parse_integer(bytes: &[u8]) -> NumberResult {
 /// Parses a float byte slice into NumberResult (only available with float feature).
 /// JSON numbers are pure ASCII, so this avoids unnecessary UTF-8 string processing.
 #[cfg(feature = "float")]
-#[inline(never)]
 pub fn parse_float(bytes: &[u8]) -> NumberResult {
     // Convert bytes to str - JSON numbers are guaranteed ASCII
     let s = match crate::shared::from_utf8(bytes) {
@@ -203,7 +200,6 @@ pub fn parse_float(bytes: &[u8]) -> NumberResult {
 /// Parses a float byte slice when float feature is disabled - behavior depends on configuration.
 /// JSON numbers are pure ASCII, so this avoids unnecessary UTF-8 string processing.
 #[cfg(not(feature = "float"))]
-#[inline(never)]
 pub fn parse_float(bytes: &[u8]) -> Result<NumberResult, ParseError> {
     // Convert bytes to str - JSON numbers are guaranteed ASCII
     let s = match crate::shared::from_utf8(bytes) {
@@ -256,7 +252,6 @@ pub fn parse_float(bytes: &[u8]) -> Result<NumberResult, ParseError> {
 ///
 /// This is the main entry point for parsing numbers with all the configured
 /// behavior (int32/int64, float support, etc.).
-#[inline(never)]
 pub fn parse_number_from_str(bytes: &[u8]) -> Result<NumberResult, ParseError> {
     if is_integer(bytes) {
         Ok(parse_integer(bytes))

--- a/picojson/src/json_number.rs
+++ b/picojson/src/json_number.rs
@@ -171,26 +171,16 @@ pub fn is_integer(bytes: &[u8]) -> bool {
 /// JSON numbers are pure ASCII, so this avoids unnecessary UTF-8 string processing.
 #[inline(never)]
 pub const fn parse_integer(bytes: &[u8]) -> NumberResult {
-    {
-        #[cfg(feature = "int8")]
-        match from_ascii_i8(bytes) {
-            Ok(val) => NumberResult::Integer(val),
-            Err(_) => NumberResult::IntegerOverflow,
-        }
-    }
+    #[cfg(feature = "int8")]
+    let result = from_ascii_i8(bytes);
     #[cfg(feature = "int32")]
-    {
-        match from_ascii_i32(bytes) {
-            Ok(val) => NumberResult::Integer(val),
-            Err(_) => NumberResult::IntegerOverflow,
-        }
-    }
+    let result = from_ascii_i32(bytes);
     #[cfg(feature = "int64")]
-    {
-        match from_ascii_i64(bytes) {
-            Ok(val) => NumberResult::Integer(val),
-            Err(_) => NumberResult::IntegerOverflow,
-        }
+    let result = from_ascii_i64(bytes);
+
+    match result {
+        Ok(val) => NumberResult::Integer(val),
+        Err(_) => NumberResult::IntegerOverflow,
     }
 }
 

--- a/picojson/src/lib.rs
+++ b/picojson/src/lib.rs
@@ -81,6 +81,7 @@ pub use json_number::{JsonNumber, NumberResult};
 mod json_string;
 pub use json_string::String;
 
+mod int_parser;
 mod number_parser;
 
 pub use slice_parser::SliceParser;

--- a/picojson/src/shared.rs
+++ b/picojson/src/shared.rs
@@ -212,7 +212,6 @@ impl ContentRange {
 pub(crate) struct ParserErrorHandler;
 
 #[cfg(not(feature = "unsafe-utf8"))]
-#[inline(never)]
 pub const fn from_utf8(v: &[u8]) -> Result<&str, ParseError> {
     match core::str::from_utf8(v) {
         Ok(s) => Ok(s),
@@ -220,7 +219,6 @@ pub const fn from_utf8(v: &[u8]) -> Result<&str, ParseError> {
     }
 }
 #[cfg(feature = "unsafe-utf8")]
-#[inline(never)]
 pub const fn from_utf8(v: &[u8]) -> Result<&str, ParseError> {
     unsafe { Ok(core::str::from_utf8_unchecked(v)) }
 }

--- a/picojson/src/shared.rs
+++ b/picojson/src/shared.rs
@@ -61,6 +61,8 @@ pub enum ParseError {
     EndOfStream,
     /// Error from the underlying reader (I/O error, not end-of-stream)
     ReaderError,
+    /// Numeric overflow
+    NumericOverflow,
 }
 
 impl From<core::str::Utf8Error> for ParseError {

--- a/picojson/src/slice_input_buffer.rs
+++ b/picojson/src/slice_input_buffer.rs
@@ -29,11 +29,11 @@ impl InputBuffer for SliceInputBuffer<'_> {
     fn consume_byte(&mut self) -> Result<u8, Error> {
         match self.data.get(self.pos) {
             Some(&byte) => {
-                self.pos = self.pos.wrapping_add(1);
+                self.pos = self.pos.checked_add(1).ok_or(Error::InvalidSliceBounds)?;
                 Ok(byte)
             }
             None => {
-                self.pos = self.pos.wrapping_add(1);
+                self.pos = self.pos.checked_add(1).ok_or(Error::InvalidSliceBounds)?;
                 Err(Error::ReachedEnd)
             }
         }

--- a/picojson/src/slice_input_buffer.rs
+++ b/picojson/src/slice_input_buffer.rs
@@ -29,11 +29,11 @@ impl InputBuffer for SliceInputBuffer<'_> {
     fn consume_byte(&mut self) -> Result<u8, Error> {
         match self.data.get(self.pos) {
             Some(&byte) => {
-                self.pos += 1;
+                self.pos = self.pos.wrapping_add(1);
                 Ok(byte)
             }
             None => {
-                self.pos += 1; // Still increment position like original logic
+                self.pos = self.pos.wrapping_add(1);
                 Err(Error::ReachedEnd)
             }
         }

--- a/picojson/src/slice_parser.rs
+++ b/picojson/src/slice_parser.rs
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn parse_number() {
-        let input = r#"{"key": 1242}"#;
+        let input = r#"{"key": 124}"#;
         let mut scratch = [0u8; 1024];
         let mut parser = SliceParser::with_buffer(input, &mut scratch);
         assert_eq!(parser.next_event(), Ok(Event::StartObject));
@@ -483,8 +483,8 @@ mod tests {
         // Check number value using new JsonNumber API
         match parser.next_event() {
             Ok(Event::Number(num)) => {
-                assert_eq!(num.as_str(), "1242");
-                assert_eq!(num.as_int(), Some(1242));
+                assert_eq!(num.as_str(), "124");
+                assert_eq!(num.as_int(), Some(124));
             }
             other => panic!("Expected Number, got: {:?}", other),
         }

--- a/picojson/src/stream_parser.rs
+++ b/picojson/src/stream_parser.rs
@@ -344,7 +344,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     fn create_unescaped_string(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.queue_unescaped_reset();
         let unescaped_slice = self.direct_buffer.get_unescaped_slice()?;
-        let str_content = ParserErrorHandler::bytes_to_utf8_str(unescaped_slice)?;
+        let str_content = crate::shared::from_utf8(unescaped_slice)?;
         Ok(Event::String(crate::String::Unescaped(str_content)))
     }
 
@@ -357,7 +357,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
         let bytes = self
             .direct_buffer
             .get_string_slice(content_start, content_end)?;
-        let str_content = ParserErrorHandler::bytes_to_utf8_str(bytes)?;
+        let str_content = crate::shared::from_utf8(bytes)?;
         Ok(Event::String(crate::String::Borrowed(str_content)))
     }
 
@@ -380,7 +380,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
     fn create_unescaped_key(&mut self) -> Result<Event<'_, '_>, ParseError> {
         self.queue_unescaped_reset();
         let unescaped_slice = self.direct_buffer.get_unescaped_slice()?;
-        let str_content = ParserErrorHandler::bytes_to_utf8_str(unescaped_slice)?;
+        let str_content = crate::shared::from_utf8(unescaped_slice)?;
         Ok(Event::Key(crate::String::Unescaped(str_content)))
     }
 
@@ -393,7 +393,7 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
         let bytes = self
             .direct_buffer
             .get_string_slice(content_start, content_end)?;
-        let str_content = ParserErrorHandler::bytes_to_utf8_str(bytes)?;
+        let str_content = crate::shared::from_utf8(bytes)?;
         Ok(Event::Key(crate::String::Borrowed(str_content)))
     }
 
@@ -482,8 +482,11 @@ impl<R: Reader, C: BitStackConfig> StreamParser<'_, R, C> {
                     ContentRange::string_content_bounds_before_escape(start_pos, current_pos);
 
                 // Estimate max length needed for unescaping (content so far + remaining buffer)
-                let max_escaped_len =
-                    self.direct_buffer.remaining_bytes() + (content_end - content_start);
+                let content_len = content_end.wrapping_sub(content_start);
+                let max_escaped_len = self
+                    .direct_buffer
+                    .remaining_bytes()
+                    .wrapping_add(content_len);
 
                 // Start unescaping with DirectBuffer and copy existing content
                 self.direct_buffer.start_unescaping_with_copy(
@@ -628,8 +631,9 @@ mod tests {
             }
 
             let to_copy = remaining.min(buf.len());
-            buf[..to_copy].copy_from_slice(&self.data[self.position..self.position + to_copy]);
-            self.position += to_copy;
+            buf[..to_copy]
+                .copy_from_slice(&self.data[self.position..self.position.wrapping_add(to_copy)]);
+            self.position = self.position.wrapping_add(to_copy);
             Ok(to_copy)
         }
     }

--- a/picojson/src/ujson/tokenizer/mod.rs
+++ b/picojson/src/ujson/tokenizer/mod.rs
@@ -329,7 +329,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
         F: FnMut(Event, usize) + ?Sized,
     {
         let consumed = self.parse_chunk_inner(data, callback)?;
-        self.total_consumed += consumed;
+        self.total_consumed = self.total_consumed.wrapping_add(consumed);
         Ok(consumed)
     }
 
@@ -397,16 +397,16 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
         F: FnMut(Event, usize) + ?Sized,
     {
         let mut pos = 0;
-        while pos < data.len() {
+        while let Some(&current_byte) = data.get(pos) {
             // Special case - this needs to be done for every Array match arm
             if let State::Array {
                 expect: Array::ItemOrEnd,
             } = &self.state
             {
-                self.check_trailing_comma(data[pos])?;
+                self.check_trailing_comma(current_byte)?;
             }
 
-            self.state = match (&self.state, data[pos]) {
+            self.state = match (&self.state, current_byte) {
                 (State::Number { state: Num::Sign }, b'0') => State::Number {
                     state: Num::LeadingZero,
                 },
@@ -414,7 +414,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     state: Num::BeforeDecimalPoint,
                 },
                 (State::Number { state: Num::Sign }, _) => {
-                    return Error::new(ErrKind::InvalidNumber, data[pos], pos);
+                    return Error::new(ErrKind::InvalidNumber, current_byte, pos);
                 }
                 (
                     State::Number {
@@ -470,7 +470,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     _,
                 ) => {
-                    return Error::new(ErrKind::InvalidNumber, data[pos], pos);
+                    return Error::new(ErrKind::InvalidNumber, current_byte, pos);
                 }
                 (
                     State::Number {
@@ -510,7 +510,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     _,
                 ) => {
-                    return Error::new(ErrKind::InvalidNumber, data[pos], pos);
+                    return Error::new(ErrKind::InvalidNumber, current_byte, pos);
                 }
                 (
                     State::Number {
@@ -526,7 +526,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     _,
                 ) => {
-                    return Error::new(ErrKind::InvalidNumber, data[pos], pos);
+                    return Error::new(ErrKind::InvalidNumber, current_byte, pos);
                 }
                 (
                     State::Number {
@@ -538,7 +538,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                 },
                 (State::Number { state: _ }, b',') => {
                     callback(Event::End(EventToken::Number), pos);
-                    self.context.after_comma = Some((data[pos], pos));
+                    self.context.after_comma = Some((current_byte, pos));
                     self.saw_a_comma_now_what()
                 }
                 (State::Number { state: _ }, b' ' | b'\t' | b'\n' | b'\r') => {
@@ -558,7 +558,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     self.maybe_exit_level()
                 }
                 (State::Number { state: _ }, _) => {
-                    return Error::new(ErrKind::InvalidNumber, data[pos], pos);
+                    return Error::new(ErrKind::InvalidNumber, current_byte, pos);
                 }
                 (
                     State::String {
@@ -597,7 +597,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     b'\x00'..=b'\x1F',
                 ) => {
-                    return Error::new(ErrKind::UnescapedControlCharacter, data[pos], pos);
+                    return Error::new(ErrKind::UnescapedControlCharacter, current_byte, pos);
                 }
                 (
                     State::String {
@@ -623,7 +623,8 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                         b'n' => EventToken::EscapeNewline,
                         b'r' => EventToken::EscapeCarriageReturn,
                         b't' => EventToken::EscapeTab,
-                        _ => unreachable!(),
+                        // This branch should never be reached due to the pattern guard above
+                        _ => return Error::new(ErrKind::InvalidStringEscape, current_byte, pos),
                     };
                     callback(Event::Begin(escape_token.clone()), pos);
                     callback(Event::End(escape_token), pos);
@@ -707,7 +708,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     _,
                 ) => {
-                    return Error::new(ErrKind::InvalidUnicodeEscape, data[pos], pos);
+                    return Error::new(ErrKind::InvalidUnicodeEscape, current_byte, pos);
                 }
                 (
                     State::Idle
@@ -726,7 +727,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     b'[',
                 ) => {
-                    self.context.enter_array(data[pos], pos)?;
+                    self.context.enter_array(current_byte, pos)?;
                     callback(Event::ArrayStart, pos);
                     State::Array {
                         expect: Array::ItemOrEnd,
@@ -742,7 +743,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     b'{',
                 ) => {
-                    self.context.enter_object(data[pos], pos)?;
+                    self.context.enter_object(current_byte, pos)?;
                     callback(Event::ObjectStart, pos);
                     State::Object {
                         expect: Object::Key,
@@ -773,7 +774,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                         expect: Array::ItemOrEnd,
                     },
                     b't' | b'f' | b'n',
-                ) => self.start_token(data[pos], pos, &mut callback)?,
+                ) => self.start_token(current_byte, pos, &mut callback)?,
                 (
                     State::Idle
                     | State::Object {
@@ -822,7 +823,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                         expect: Object::Value,
                     },
                     _,
-                ) => return Error::new(ErrKind::ExpectedObjectValue, data[pos], pos),
+                ) => return Error::new(ErrKind::ExpectedObjectValue, current_byte, pos),
                 (
                     State::Array {
                         expect: Array::ItemOrEnd,
@@ -872,7 +873,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     b',',
                 ) => {
-                    self.context.after_comma = Some((data[pos], pos));
+                    self.context.after_comma = Some((current_byte, pos));
                     State::Object {
                         expect: Object::Key,
                     }
@@ -893,7 +894,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                     },
                     b',',
                 ) => {
-                    self.context.after_comma = Some((data[pos], pos));
+                    self.context.after_comma = Some((current_byte, pos));
                     State::Array {
                         expect: Array::ItemOrEnd,
                     }
@@ -994,7 +995,7 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
 
                 // Wrong tokens
                 (State::Idle, _) => {
-                    return Error::new(ErrKind::InvalidRoot, data[pos], pos);
+                    return Error::new(ErrKind::InvalidRoot, current_byte, pos);
                 }
                 (
                     State::String {
@@ -1002,25 +1003,25 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                         key: _,
                     },
                     _,
-                ) => return Error::new(ErrKind::InvalidStringEscape, data[pos], pos),
+                ) => return Error::new(ErrKind::InvalidStringEscape, current_byte, pos),
                 (
                     State::Object {
                         expect: Object::Key,
                     },
                     _,
-                ) => return Error::new(ErrKind::ExpectedObjectKey, data[pos], pos),
+                ) => return Error::new(ErrKind::ExpectedObjectKey, current_byte, pos),
                 (
                     State::Object {
                         expect: Object::Colon,
                     },
                     _,
-                ) => return Error::new(ErrKind::ExpectedColon, data[pos], pos),
+                ) => return Error::new(ErrKind::ExpectedColon, current_byte, pos),
                 (
                     State::Object {
                         expect: Object::CommaOrEnd,
                     },
                     _,
-                ) => return Error::new(ErrKind::ExpectedObjectValue, data[pos], pos),
+                ) => return Error::new(ErrKind::ExpectedObjectValue, current_byte, pos),
                 (
                     State::Array {
                         expect: Array::ItemOrEnd,
@@ -1029,13 +1030,15 @@ impl<T: BitBucket, D: DepthCounter> Tokenizer<T, D> {
                         expect: Array::CommaOrEnd,
                     },
                     _,
-                ) => return Error::new(ErrKind::ExpectedArrayItem, data[pos], pos),
-                (State::Finished, _) => return Error::new(ErrKind::ContentEnded, data[pos], pos),
+                ) => return Error::new(ErrKind::ExpectedArrayItem, current_byte, pos),
+                (State::Finished, _) => {
+                    return Error::new(ErrKind::ContentEnded, current_byte, pos)
+                }
                 (State::Token { token: _ }, _) => {
-                    return Error::new(ErrKind::InvalidToken, data[pos], pos)
+                    return Error::new(ErrKind::InvalidToken, current_byte, pos)
                 }
             };
-            pos += 1;
+            pos = pos.saturating_add(1);
         }
         Ok(pos)
     }

--- a/picojson/tests/configurable_numbers.rs
+++ b/picojson/tests/configurable_numbers.rs
@@ -111,18 +111,18 @@ fn test_float_truncate_to_i32() {
     feature = "float-truncate",
     not(feature = "int32")
 ))]
-fn test_float_truncate_to_i64() {
+fn test_float_truncate_to_integer() {
     let input = r#"[1.7, 2.9, 3.1]"#;
     let mut scratch = [0u8; 1024];
     let mut parser = SliceParser::with_buffer(input, &mut scratch);
 
     assert!(matches!(parser.next_event(), Ok(Event::StartArray)));
 
-    // Should truncate to i64 values
+    // Should truncate to integer
     match parser.next_event() {
         Ok(Event::Number(num)) => {
             assert_eq!(num.as_str(), "1.7");
-            assert!(matches!(num.parsed(), NumberResult::FloatTruncated(1i64)));
+            assert!(matches!(num.parsed(), NumberResult::FloatTruncated(1)));
         }
         other => panic!("Expected truncated Number, got: {:?}", other),
     }


### PR DESCRIPTION
Partially address #24 

## Summary by Sourcery

Migrate SliceParser and related modules to a fully panic-free, byte-slice-based design and introduce configurable, const integer parsing support. Update build configurations and CI workflows to validate multiple feature combinations and enforce panic-free code paths.

New Features:
- Parse JSON numbers directly from byte slices to eliminate UTF-8 &str panics
- Introduce const, panic-free integer parsers for i8, i32, and i64 via a new int_parser module
- Add an unsafe-utf8 feature for unchecked UTF-8 conversion in no-panic contexts

Enhancements:
- Refactor internal parsers (Tokenizer, DirectBuffer, CopyOnEscape, BitStack) to replace panic-prone indexing and copy methods with safe get, zip loops, wrapping/saturating arithmetic
- Unify UTF-8 error handling with a shared from_utf8 API and migrate number parsing to byte-oriented logic
- Add compile-time feature checks to enforce mutually exclusive integer-width options

CI:
- Expand CI and build workflows to a feature matrix covering int8/int32, float behaviors, profiles, and panic-free verification using cargo nm
- Update pre-commit hooks and GitHub Actions for new int and float feature combinations

Tests:
- Adjust existing tests and examples to reflect byte-slice number parsing and int8 defaults

Chores:
- Add custom panic handler in avr_demo to ensure no default panic dependencies
- Update TODO and demos to align with no-panic objectives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for 8-bit integer parsing and an "unsafe-utf8" feature for improved UTF-8 handling.
  * Introduced a const-stable, panic-free integer parser for multiple integer widths.
  * Made key parsing and escape processing structs publicly accessible.

* **Bug Fixes**
  * Enhanced safety by replacing unchecked indexing and arithmetic with safe, saturating, or wrapping operations to prevent panics.
  * Improved error handling to avoid panics during parsing, buffer operations, and escape sequence processing.
  * Added compile-time checks to ensure exactly one integer width feature is enabled.

* **Refactor**
  * Refactored number parsing to operate directly on byte slices for better performance.
  * Simplified UTF-8 conversions with optional unsafe mode for performance.
  * Updated test cases and messages for clarity and accuracy.

* **Chores**
  * Enhanced CI and pre-commit checks to cover new feature combinations and improve test coverage.
  * Updated workflow and build configurations to reflect new features and safer defaults.
  * Replaced panic handler imports with a unified custom handler in demos and examples.

* **Documentation**
  * Added a TODO item highlighting removal of panic-prone slice copying methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->