### PR TITLE
Add workflow caching

### DIFF
--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -17,15 +17,41 @@ jobs:
         with:
           components: rust-src
 
-      - name: Install simavr and dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y simavr gcc-avr avr-libc
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            avr_demo
+            picojson
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: simavr gcc-avr avr-libc
+          version: 1.0
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-bloat
+            ~/.cargo/bin/cargo-nm
+            ~/.cargo/bin/cargo-objcopy
+            ~/.cargo/bin/cargo-objdump
+            ~/.cargo/bin/cargo-size
+            ~/.cargo/bin/cargo-strip
+          key: ${{ runner.os }}-cargo-bins-bloat-binutils-v1
 
       - name: Install cargo-bloat
-        run: cargo install cargo-bloat
+        run: |
+          if ! command -v cargo-bloat &> /dev/null; then
+            cargo install cargo-bloat --locked
+          fi
       - name: Install cargo-binutils
-        run: cargo install cargo-binutils
+        run: |
+          if ! command -v cargo-nm &> /dev/null; then
+            cargo install cargo-binutils --locked
+          fi
 
       - name: Run Stack Analysis
         working-directory: avr_demo
@@ -54,13 +80,35 @@ jobs:
         with:
           components: rust-src
 
-      - name: Install simavr and dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y simavr gcc-avr avr-libc
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            avr_demo
+            picojson
+
+      - name: Cache APT packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: simavr gcc-avr avr-libc
+          version: 1.0
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-nm
+            ~/.cargo/bin/cargo-objcopy
+            ~/.cargo/bin/cargo-objdump
+            ~/.cargo/bin/cargo-size
+            ~/.cargo/bin/cargo-strip
+          key: ${{ runner.os }}-cargo-binutils-v1
 
       - name: Install cargo-binutils
-        run: cargo install cargo-binutils
+        run: |
+          if ! command -v cargo-nm &> /dev/null; then
+            cargo install cargo-binutils --locked
+          fi
 
       - name: Build the demos in ${{ matrix.profile }} mode
         working-directory: avr_demo

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Run cargo check
         run: cargo check
 
@@ -62,6 +65,9 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo test
         working-directory: picojson

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           components: llvm-tools-preview  # Needed for cargo-llvm-cov
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce extensive caching to GitHub workflows to speed up CI by reusing Rust dependencies, APT packages, and cargo tool binaries, and make cargo tool installations idempotent.

Enhancements:
- Cache Rust dependencies in build, test, and coverage workflows using Swatinem/rust-cache
- Cache APT packages (simavr, gcc-avr, avr-libc) in AVR test workflows with cache-apt-pkgs-action
- Cache cargo tool binaries (cargo-bloat and cargo-binutils) in AVR test workflows
- Add conditional checks before installing cargo-bloat and cargo-binutils to avoid redundant installations

CI:
- Integrate actions/cache, Swatinem/rust-cache, and cache-apt-pkgs-action into all CI workflows