### PR TITLE
Fix bloat suite to test with correct flags

### DIFF
--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -100,8 +100,8 @@ def run_bloat_analysis():
     results = {}
 
     bloat_configs = [
-        ("serde", "test_serde", []),
-        ("picojson", "test_picojson", []),
+        ("serde", "test_serde", ["int8"]),
+        ("picojson", "test_picojson", ["pico-tiny,int8"]),
     ]
 
     # Bloat analysis doesn't depend on nesting depth, so we run it once for each config.
@@ -111,6 +111,7 @@ def run_bloat_analysis():
         # Construct the cargo bloat command
         command = ["cargo", "bloat", "--release", "--message-format=json"]
         if extra_features:
+            command.append("--no-default-features")
             command.append("--features")
             command.append(",".join(extra_features))
         command.extend(["--example", example])

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -101,7 +101,7 @@ def run_bloat_analysis():
 
     bloat_configs = [
         ("serde", "test_serde", ["int8"]),
-        ("picojson", "test_picojson", ["pico-tiny,int8"]),
+        ("picojson", "test_picojson", ["pico-tiny", "int8"]),
     ]
 
     # Bloat analysis doesn't depend on nesting depth, so we run it once for each config.
@@ -111,9 +111,13 @@ def run_bloat_analysis():
         # Construct the cargo bloat command
         command = ["cargo", "bloat", "--release", "--message-format=json"]
         if extra_features:
-            command.append("--no-default-features")
-            command.append("--features")
-            command.append(",".join(extra_features))
+            command.extend(
+                (
+                    "--no-default-features",
+                    "--features",
+                    ",".join(extra_features),
+                )
+            )
         command.extend(["--example", example])
 
         try:


### PR DESCRIPTION
## Summary by Sourcery

Fix the AVR demo bloat analysis script to use the correct feature flags when running cargo bloat

Bug Fixes:
- Update bloat test configurations to include the 'int8' and 'pico-tiny,int8' feature sets
- Add the --no-default-features flag before specifying features in the cargo bloat command