### PR TITLE
Error structure cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 - [x] Remove copy_from_slice - can panic
 - [x] Remove all bounds checked slice indexing that could panic!
 - [x] Verify we are fully panic! free
-- [ ] Remove unnecessary `'static` lifetimes
+- [x] Remove unnecessary `'static` lifetime errors
 - [x] Dependency cleanup
 - [x] Clippy cleanup
 - [ ] Unify code in SliceParser and StreamParser
@@ -12,8 +12,8 @@
 - [ ] Clean up reference docs
 - [ ] Provide user guide docs
 - [ ] Direct defmt support
-- [ ] Stack size benchmarks
-- [ ] Code size benchmarks
+- [x] Stack size benchmarks
+- [x]  Code size benchmarks
 - [ ] Sax-style push parser
 - [x] See if we can bring an Iterator impl back
     - Can't practically be done with borrowing return values

--- a/picojson/src/copy_on_escape.rs
+++ b/picojson/src/copy_on_escape.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ParseError, String};
+use crate::parse_error::ParseError;
+use crate::{shared::UnexpectedState, String};
 
 /// A struct that encapsulates copy-on-escape string processing with full buffer ownership.
 ///
@@ -70,7 +71,7 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
             let span = self
                 .input
                 .get(self.last_copied_pos..end)
-                .ok_or(ParseError::UnexpectedState("Invalid span"))?;
+                .ok_or(UnexpectedState::InvalidSliceBounds)?;
             let end_pos = self
                 .scratch_pos
                 .checked_add(span.len())
@@ -191,7 +192,7 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
             let unescaped_slice = self
                 .scratch
                 .get(self.scratch_start..self.scratch_pos)
-                .ok_or(ParseError::UnexpectedState("Invalid scratch slice"))?;
+                .ok_or(UnexpectedState::InvalidSliceBounds)?;
             let unescaped_str = crate::shared::from_utf8(unescaped_slice)?;
             Ok(String::Unescaped(unescaped_str))
         } else {
@@ -199,7 +200,7 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
             let borrowed_bytes = self
                 .input
                 .get(self.string_start..pos)
-                .ok_or(ParseError::UnexpectedState("Invalid input slice"))?;
+                .ok_or(UnexpectedState::InvalidSliceBounds)?;
             let borrowed_str = crate::shared::from_utf8(borrowed_bytes)?;
             Ok(String::Borrowed(borrowed_str))
         }

--- a/picojson/src/lib.rs
+++ b/picojson/src/lib.rs
@@ -69,8 +69,11 @@ mod stream_parser;
 
 mod slice_parser;
 
+mod parse_error;
+pub use parse_error::ParseError;
+
 mod shared;
-pub use shared::{Event, ParseError, PullParser};
+pub use shared::{Event, PullParser};
 
 mod slice_input_buffer;
 
@@ -86,14 +89,3 @@ mod number_parser;
 
 pub use slice_parser::SliceParser;
 pub use stream_parser::{Reader, StreamParser};
-
-impl From<slice_input_buffer::Error> for ParseError {
-    fn from(err: slice_input_buffer::Error) -> Self {
-        match err {
-            slice_input_buffer::Error::ReachedEnd => ParseError::EndOfData,
-            slice_input_buffer::Error::InvalidSliceBounds => {
-                ParseError::UnexpectedState("Invalid slice bounds in input buffer")
-            }
-        }
-    }
-}

--- a/picojson/src/number_parser.rs
+++ b/picojson/src/number_parser.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{Event, ParseError};
+use crate::parse_error::ParseError;
+use crate::shared::Event;
+#[cfg(test)]
+use crate::shared::UnexpectedState;
 use crate::JsonNumber;
 
 /// Trait for extracting number slices from different buffer implementations.
@@ -62,7 +65,6 @@ pub fn parse_number_event<T: NumberExtractor>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared::ParserErrorHandler;
 
     // Mock extractor for testing
     struct MockExtractor {
@@ -84,9 +86,7 @@ mod tests {
     impl NumberExtractor for MockExtractor {
         fn get_number_slice(&self, start: usize, end: usize) -> Result<&[u8], ParseError> {
             if end > self.data.len() {
-                return Err(ParserErrorHandler::unexpected_state(
-                    "End position beyond buffer",
-                ));
+                return Err(UnexpectedState::InvalidSliceBounds.into());
             }
             Ok(&self.data[start..end])
         }

--- a/picojson/src/parse_error.rs
+++ b/picojson/src/parse_error.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::shared::UnexpectedState;
+use crate::slice_input_buffer;
+use crate::stream_buffer;
+
+/// Errors that can occur during JSON parsing
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    /// An error bubbled up from the underlying tokenizer.
+    TokenizerError,
+    /// The provided scratch buffer was not large enough for an operation.
+    ScratchBufferFull,
+    /// A string slice was not valid UTF-8.
+    InvalidUtf8(core::str::Utf8Error),
+    /// A number string could not be parsed.
+    InvalidNumber,
+    /// The parser entered an unexpected internal state.
+    Unexpected(UnexpectedState),
+    /// End of input data.
+    EndOfData,
+    /// Invalid hex digits in Unicode escape sequence.
+    InvalidUnicodeHex,
+    /// Valid hex but invalid Unicode codepoint.
+    InvalidUnicodeCodepoint,
+    /// Invalid escape sequence character.
+    InvalidEscapeSequence,
+    /// Float encountered but float support is disabled and float-error is configured
+    FloatNotAllowed,
+    /// Error from the underlying reader (I/O error, not end-of-stream)
+    ReaderError,
+    /// Numeric overflow
+    NumericOverflow,
+}
+
+impl From<slice_input_buffer::Error> for ParseError {
+    fn from(err: slice_input_buffer::Error) -> Self {
+        match err {
+            slice_input_buffer::Error::ReachedEnd => ParseError::EndOfData,
+            slice_input_buffer::Error::InvalidSliceBounds => {
+                UnexpectedState::InvalidSliceBounds.into()
+            }
+        }
+    }
+}
+
+impl From<stream_buffer::StreamBufferError> for ParseError {
+    fn from(err: stream_buffer::StreamBufferError) -> Self {
+        match err {
+            stream_buffer::StreamBufferError::BufferFull => ParseError::ScratchBufferFull,
+            stream_buffer::StreamBufferError::EndOfData => ParseError::EndOfData,
+            stream_buffer::StreamBufferError::Unexpected => {
+                ParseError::Unexpected(UnexpectedState::BufferCapacityExceeded)
+            }
+            stream_buffer::StreamBufferError::InvalidSliceBounds => {
+                ParseError::Unexpected(UnexpectedState::InvalidSliceBounds)
+            }
+        }
+    }
+}
+
+impl From<core::str::Utf8Error> for ParseError {
+    fn from(err: core::str::Utf8Error) -> Self {
+        ParseError::InvalidUtf8(err)
+    }
+}
+
+impl From<UnexpectedState> for ParseError {
+    fn from(info: UnexpectedState) -> Self {
+        ParseError::Unexpected(info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_constructors() {
+        // Test state_mismatch error constructor
+        let error: ParseError = UnexpectedState::StateMismatch.into();
+        match error {
+            ParseError::Unexpected(info) => {
+                assert_eq!(info, UnexpectedState::StateMismatch);
+            }
+            _ => panic!("Expected UnexpectedState error"),
+        }
+
+        // Test invalid_unicode_length error constructor
+        let error: ParseError = UnexpectedState::InvalidUnicodeEscape.into();
+        match error {
+            ParseError::Unexpected(info) => {
+                assert_eq!(info, UnexpectedState::InvalidUnicodeEscape);
+            }
+            _ => panic!("Expected UnexpectedState error"),
+        }
+
+        // Test incomplete_unicode_escape error constructor
+        let error: ParseError = UnexpectedState::InvalidUnicodeEscape.into();
+        match error {
+            ParseError::Unexpected(info) => {
+                assert_eq!(info, UnexpectedState::InvalidUnicodeEscape);
+            }
+            _ => panic!("Expected UnexpectedState error"),
+        }
+    }
+
+    #[test]
+    fn test_utf8_error_conversion() {
+        // Test From<Utf8Error> trait implementation
+        use core::str;
+        // Create a proper invalid UTF-8 sequence (lone continuation byte) dynamically
+        // to avoid compile-time warning about static invalid UTF-8 literals
+        let mut invalid_utf8_array = [0u8; 1];
+        invalid_utf8_array[0] = 0b10000000u8; // Invalid UTF-8 - continuation byte without start
+        let invalid_utf8 = &invalid_utf8_array;
+
+        match str::from_utf8(invalid_utf8) {
+            Err(utf8_error) => {
+                let parse_error: ParseError = utf8_error.into();
+                match parse_error {
+                    ParseError::InvalidUtf8(_) => {
+                        // Expected - conversion works correctly
+                    }
+                    _ => panic!("Expected InvalidUtf8 error"),
+                }
+            }
+            Ok(_) => panic!("Expected UTF-8 validation to fail"),
+        }
+    }
+}

--- a/picojson/src/shared.rs
+++ b/picojson/src/shared.rs
@@ -153,9 +153,6 @@ impl ContentRange {
     }
 }
 
-pub const fn from_utf8(v: &[u8]) -> Result<&str, ParseError> {
-    match core::str::from_utf8(v) {
-        Ok(s) => Ok(s),
-        Err(e) => Err(ParseError::InvalidUtf8(e)),
-    }
+pub fn from_utf8(v: &[u8]) -> Result<&str, ParseError> {
+    core::str::from_utf8(v).map_err(Into::into)
 }

--- a/picojson/src/slice_input_buffer.rs
+++ b/picojson/src/slice_input_buffer.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::ParseError;
+
 /// Error type for SliceInputBuffer operations.
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -55,13 +57,9 @@ impl<'a> SliceInputBuffer<'a> {
 }
 
 impl crate::number_parser::NumberExtractor for SliceInputBuffer<'_> {
-    fn get_number_slice(
-        &self,
-        start: usize,
-        end: usize,
-    ) -> Result<&[u8], crate::shared::ParseError> {
+    fn get_number_slice(&self, start: usize, end: usize) -> Result<&[u8], ParseError> {
         self.slice(start, end)
-            .map_err(|_| crate::shared::ParseError::InvalidNumber)
+            .map_err(|_| ParseError::InvalidNumber)
     }
 
     fn current_position(&self) -> usize {

--- a/picojson/src/slice_parser.rs
+++ b/picojson/src/slice_parser.rs
@@ -2,9 +2,8 @@
 
 use crate::copy_on_escape::CopyOnEscape;
 use crate::escape_processor::{EscapeProcessor, UnicodeEscapeCollector};
-use crate::shared::{
-    ContentRange, Event, ParseError, ParserErrorHandler, ParserState, PullParser, State,
-};
+use crate::parse_error::ParseError;
+use crate::shared::{ContentRange, Event, ParserState, PullParser, State, UnexpectedState};
 use crate::slice_input_buffer::{InputBuffer, SliceInputBuffer};
 use crate::ujson;
 use ujson::{EventToken, Tokenizer};
@@ -242,9 +241,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                 self.tokenizer.finish(&mut callback)
             }
             Err(crate::slice_input_buffer::Error::InvalidSliceBounds) => {
-                return Err(ParseError::UnexpectedState(
-                    "Invalid slice bounds in consume_byte",
-                ));
+                return Err(UnexpectedState::InvalidSliceBounds.into());
             }
             Ok(byte) => self.tokenizer.parse_chunk(&[byte], &mut callback),
         };
@@ -390,7 +387,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                     }
                     #[cfg(test)]
                     ujson::Event::Uninitialized => {
-                        return Err(ParseError::UnexpectedState("Uninitialized event"));
+                        return Err(ParseError::Unexpected(UnexpectedState::StateMismatch));
                     }
                 };
                 match res {
@@ -406,7 +403,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                             let key_result = self.copy_on_escape.end_string(end_pos)?;
                             break Ok(Event::Key(key_result));
                         } else {
-                            break Err(ParserErrorHandler::state_mismatch("key", "end"));
+                            break Err(UnexpectedState::StateMismatch.into());
                         }
                     }
                     EventResult::ExtractString => {
@@ -419,7 +416,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                             let value_result = self.copy_on_escape.end_string(end_pos)?;
                             break Ok(Event::String(value_result));
                         } else {
-                            break Err(ParserErrorHandler::state_mismatch("string", "end"));
+                            break Err(UnexpectedState::StateMismatch.into());
                         }
                     }
                     EventResult::ExtractNumber(from_container_end) => {
@@ -431,17 +428,13 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                                 .parse_number_from_buffer(number_token_start, from_container_end)?;
                             break Ok(event);
                         } else {
-                            break Err(ParseError::UnexpectedState(
-                                "Number end without Number start",
-                            ));
+                            break Err(UnexpectedState::StateMismatch.into());
                         }
                     }
                 }
             } else {
                 // No event available - this shouldn't happen since we ensured have_events() above
-                break Err(ParseError::UnexpectedState(
-                    "No events available after ensuring events exist",
-                ));
+                break Err(UnexpectedState::StateMismatch.into());
             }
         }
     }

--- a/picojson/src/slice_parser.rs
+++ b/picojson/src/slice_parser.rs
@@ -240,8 +240,8 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
             Err(crate::slice_input_buffer::Error::ReachedEnd) => {
                 self.tokenizer.finish(&mut callback)
             }
-            Err(crate::slice_input_buffer::Error::InvalidSliceBounds) => {
-                return Err(UnexpectedState::InvalidSliceBounds.into());
+            Err(err) => {
+                return Err(err.into());
             }
             Ok(byte) => self.tokenizer.parse_chunk(&[byte], &mut callback),
         };
@@ -387,7 +387,7 @@ impl<'a, 'b, C: BitStackConfig> SliceParser<'a, 'b, C> {
                     }
                     #[cfg(test)]
                     ujson::Event::Uninitialized => {
-                        return Err(ParseError::Unexpected(UnexpectedState::StateMismatch));
+                        return Err(UnexpectedState::StateMismatch.into());
                     }
                 };
                 match res {

--- a/picojson/src/stream_buffer.rs
+++ b/picojson/src/stream_buffer.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::shared::UnexpectedState;
 use crate::ParseError;
 
 /// Error types for StreamBuffer operations
@@ -9,18 +10,10 @@ pub enum StreamBufferError {
     BufferFull,
     /// Attempted to read beyond available data
     EndOfData,
-    /// Invalid buffer state or operation
-    InvalidState(&'static str),
-}
-
-impl From<StreamBufferError> for ParseError {
-    fn from(err: StreamBufferError) -> Self {
-        match err {
-            StreamBufferError::BufferFull => ParseError::ScratchBufferFull,
-            StreamBufferError::EndOfData => ParseError::EndOfData,
-            StreamBufferError::InvalidState(msg) => ParseError::UnexpectedState(msg),
-        }
-    }
+    /// An unexpected error occurred.
+    Unexpected,
+    /// Invalid slice bounds provided for string extraction
+    InvalidSliceBounds,
 }
 
 /// StreamBuffer manages a single buffer for both input and escape processing
@@ -159,9 +152,7 @@ impl<'a> StreamBuffer<'a> {
 
             let src_range = start_offset..start_offset.wrapping_add(span_len);
             if src_range.end > self.buffer.len() {
-                return Err(StreamBufferError::InvalidState(
-                    "Source range out of bounds",
-                ));
+                return Err(StreamBufferError::InvalidSliceBounds);
             }
 
             // Copy within the same buffer: move data from [start_offset..end] to [0..span_len]
@@ -180,9 +171,7 @@ impl<'a> StreamBuffer<'a> {
     pub fn mark_filled(&mut self, bytes_read: usize) -> Result<(), StreamBufferError> {
         let new_data_end = self.data_end.wrapping_add(bytes_read);
         if new_data_end > self.buffer.len() {
-            return Err(StreamBufferError::InvalidState(
-                "Attempted to mark more bytes than buffer space",
-            ));
+            return Err(StreamBufferError::Unexpected);
         }
         self.data_end = new_data_end;
         Ok(())
@@ -215,9 +204,7 @@ impl<'a> StreamBuffer<'a> {
 
             let src_range = copy_start..copy_start.wrapping_add(span_len);
             if src_range.end > self.buffer.len() {
-                return Err(StreamBufferError::InvalidState(
-                    "Source range out of bounds",
-                ));
+                return Err(StreamBufferError::InvalidSliceBounds);
             }
 
             // Copy within the same buffer: move data from [copy_start..copy_end] to [0..span_len]
@@ -232,15 +219,11 @@ impl<'a> StreamBuffer<'a> {
     /// Get the unescaped content slice
     pub fn get_unescaped_slice(&self) -> Result<&[u8], StreamBufferError> {
         if self.unescaped_len == 0 {
-            return Err(StreamBufferError::InvalidState(
-                "No unescaped content available",
-            ));
+            return Err(StreamBufferError::InvalidSliceBounds);
         }
         self.buffer
             .get(0..self.unescaped_len)
-            .ok_or(StreamBufferError::InvalidState(
-                "Unescaped length exceeds buffer size",
-            ))
+            .ok_or(StreamBufferError::Unexpected)
     }
 
     /// Clear unescaped content (call after yielding unescaped string)
@@ -278,11 +261,11 @@ impl<'a> StreamBuffer<'a> {
     /// Used for strings without escapes
     pub fn get_string_slice(&self, start: usize, end: usize) -> Result<&[u8], StreamBufferError> {
         if start > end || end > self.data_end {
-            return Err(StreamBufferError::InvalidState("Invalid slice bounds"));
+            return Err(StreamBufferError::InvalidSliceBounds);
         }
         self.buffer
             .get(start..end)
-            .ok_or(StreamBufferError::InvalidState("Invalid slice bounds"))
+            .ok_or(StreamBufferError::InvalidSliceBounds)
     }
 }
 
@@ -1017,13 +1000,9 @@ mod tests {
 }
 
 impl crate::number_parser::NumberExtractor for StreamBuffer<'_> {
-    fn get_number_slice(
-        &self,
-        start: usize,
-        end: usize,
-    ) -> Result<&[u8], crate::shared::ParseError> {
+    fn get_number_slice(&self, start: usize, end: usize) -> Result<&[u8], ParseError> {
         self.get_string_slice(start, end)
-            .map_err(|_| crate::shared::ParseError::UnexpectedState("Invalid number slice bounds"))
+            .map_err(|_| UnexpectedState::InvalidSliceBounds.into())
     }
 
     fn current_position(&self) -> usize {

--- a/picojson/src/stream_buffer.rs
+++ b/picojson/src/stream_buffer.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::UnexpectedState;
 use crate::ParseError;
 
 /// Error types for StreamBuffer operations
@@ -1001,8 +1000,7 @@ mod tests {
 
 impl crate::number_parser::NumberExtractor for StreamBuffer<'_> {
     fn get_number_slice(&self, start: usize, end: usize) -> Result<&[u8], ParseError> {
-        self.get_string_slice(start, end)
-            .map_err(|_| UnexpectedState::InvalidSliceBounds.into())
+        self.get_string_slice(start, end).map_err(Into::into)
     }
 
     fn current_position(&self) -> usize {


### PR DESCRIPTION
## Summary by Sourcery

Refactor and centralize JSON parsing error handling by extracting ParseError into its own module, replacing ad-hoc string-based error contexts with a dedicated UnexpectedState enum, and updating all related error types and conversions accordingly.

Enhancements:
- Extract ParseError into a new parse_error module and remove the monolithic shared.rs definition
- Introduce UnexpectedState enum for all unexpected conditions, replacing string-based error messages
- Simplify StreamBuffer and SliceInputBuffer error variants to explicit cases and update their From conversions to ParseError
- Remove the ParserErrorHandler utility and inline error construction using UnexpectedState and From implementations
- Update error handling across slice_parser, stream_parser, escape_processor, copy_on_escape, and number_parser to use the new error types

Tests:
- Relocate and adjust error conversion unit tests into parse_error module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling across JSON parsing by introducing structured error enums for greater clarity and consistency.
  * Replaced string-based error messages with specific error variants.
  * Centralized and streamlined error type definitions, moving and updating public error enums.
  * Updated method signatures to use new error types where applicable.

* **Bug Fixes**
  * Enhanced accuracy and specificity of error reporting for invalid states and slice bounds during parsing.

* **Documentation**
  * Updated TODO list to reflect completed tasks and made minor formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->