### PR TITLE
Remove detritus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 resolver = "2"
-members = ["picojson", "demos"]
+members = ["picojson"]
 
 exclude = ["avr_demo"]

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -1,4 +1,0 @@
-[package]
-name = "demos"
-version = "0.0.1"
-edition = "2021"

--- a/demos/src/lib.rs
+++ b/demos/src/lib.rs
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-
-//! Demos crate for picojson-rs
-//!
-//! This crate contains demonstration code and examples.
-
-#![cfg_attr(not(test), no_std)]


### PR DESCRIPTION
## Summary by Sourcery

Remove the unused demos crate and its references from the workspace

Chores:
- Remove "demos" from the workspace members list in Cargo.toml
- Delete the demos crate directory and its Cargo.toml and source file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "demos" project from the workspace and deleted its associated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->