### PR TITLE
Less workflows

### DIFF
--- a/.github/workflows/avr_tests.yaml
+++ b/.github/workflows/avr_tests.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
 
 name: AVR Tests
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
 
 name: Build and test
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,9 @@ name: Coverage
 on:
   push:
     branches:
-      - '*'
+      - main
+      - 'feature/**'
   pull_request:
-    branches:
-      - '*'
 
 
 jobs:

--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
 
 name: Cross-compile
 


### PR DESCRIPTION
## Summary by Sourcery

Streamline GitHub Actions workflows by restricting push event triggers to the main branch and feature branches while retaining pull request triggers

CI:
- Restrict push triggers in all workflows to run only on the main and 'feature/**' branches
- Preserve pull request triggers for all workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers to run on pushes only to the main branch and feature branches, instead of all branches.
  * Adjusted coverage workflow to no longer run on pull requests.
  * Maintained pull request triggers for most workflows without branch restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->