### PR TITLE
Add deny missing docs

### DIFF
--- a/picojson/src/json_number.rs
+++ b/picojson/src/json_number.rs
@@ -50,9 +50,19 @@ pub enum NumberResult {
 #[derive(Debug, PartialEq)]
 pub enum JsonNumber<'a, 'b> {
     /// A raw slice from the original input, used when no copying is needed.
-    Borrowed { raw: &'a str, parsed: NumberResult },
+    Borrowed {
+        /// The exact string representation of the number from the input.
+        raw: &'a str,
+        /// The result of parsing the number according to crate features.
+        parsed: NumberResult,
+    },
     /// A slice from the scratch/copy buffer, used when number had to be copied.
-    Copied { raw: &'b str, parsed: NumberResult },
+    Copied {
+        /// The exact string representation of the number from the copy buffer.
+        raw: &'b str,
+        /// The result of parsing the number according to crate features.
+        parsed: NumberResult,
+    },
 }
 
 impl JsonNumber<'_, '_> {

--- a/picojson/src/lib.rs
+++ b/picojson/src/lib.rs
@@ -49,6 +49,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![cfg_attr(not(test), no_std)]
+#![deny(missing_docs)]
 
 // Compile-time configuration validation
 mod config_check;

--- a/picojson/src/ujson/bitstack/mod.rs
+++ b/picojson/src/ujson/bitstack/mod.rs
@@ -88,7 +88,11 @@ impl_depth_counter!(u8, u16, u32, u64, u128, usize);
 
 /// Configuration trait for BitStack systems - defines bucket and counter types.
 pub trait BitStackConfig {
+    /// The type used for storing the bit stack (e.g., u32, or a custom array-based type).
+    /// This type must implement the [`BitBucket`] trait.
     type Bucket: BitBucket + Default;
+    /// The type used for tracking nesting depth (e.g., u8).
+    /// This type must implement the [`DepthCounter`] trait.
     type Counter: DepthCounter + Default;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce documentation coverage by enabling `missing_docs` lint and add missing documentation for JSON number types and BitStack configuration.

Documentation:
- Enable `#![deny(missing_docs)]` in the crate root
- Add doc comments to `JsonNumber` variants and their fields
- Add doc comments to `BitStackConfig` associated types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for enum variants in number handling, clarifying field purposes.
  * Enhanced trait documentation for configuration types in bit stack handling.
  * Enforced comprehensive documentation for all public items in the crate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->