### PR TITLE
Introduce DataSource abstraction

### DIFF
--- a/picojson/src/copy_on_escape.rs
+++ b/picojson/src/copy_on_escape.rs
@@ -205,6 +205,27 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
             Ok(String::Borrowed(borrowed_str))
         }
     }
+
+    /// DataSource support methods - check if unescaped content is available
+    pub fn has_unescaped_content(&self) -> bool {
+        self.using_scratch
+    }
+
+    /// Direct access to scratch buffer with proper lifetime for DataSource implementation
+    pub fn get_scratch_buffer_slice(
+        &'b self,
+        start: usize,
+        end: usize,
+    ) -> Result<&'b [u8], ParseError> {
+        self.scratch
+            .get(start..end)
+            .ok_or(ParseError::Unexpected(UnexpectedState::InvalidSliceBounds))
+    }
+
+    /// Get scratch buffer range for current string
+    pub fn get_scratch_range(&self) -> (usize, usize) {
+        (self.scratch_start, self.scratch_pos)
+    }
 }
 
 #[cfg(test)]

--- a/picojson/src/copy_on_escape.rs
+++ b/picojson/src/copy_on_escape.rs
@@ -212,19 +212,10 @@ impl<'a, 'b> CopyOnEscape<'a, 'b> {
     }
 
     /// Direct access to scratch buffer with proper lifetime for DataSource implementation
-    pub fn get_scratch_buffer_slice(
-        &'b self,
-        start: usize,
-        end: usize,
-    ) -> Result<&'b [u8], ParseError> {
+    pub fn get_scratch_contents(&'b self) -> Result<&'b [u8], ParseError> {
         self.scratch
-            .get(start..end)
+            .get(self.scratch_start..self.scratch_pos)
             .ok_or(ParseError::Unexpected(UnexpectedState::InvalidSliceBounds))
-    }
-
-    /// Get scratch buffer range for current string
-    pub fn get_scratch_range(&self) -> (usize, usize) {
-        (self.scratch_start, self.scratch_pos)
     }
 }
 

--- a/picojson/src/escape_processor.rs
+++ b/picojson/src/escape_processor.rs
@@ -695,9 +695,7 @@ where
 
     // Create a temporary collector to process the hex digits
     let mut temp_collector = UnicodeEscapeCollector::new();
-    if let Some(surrogate) = pending_high_surrogate {
-        temp_collector.set_pending_high_surrogate(Some(surrogate));
-    }
+    temp_collector.set_pending_high_surrogate(pending_high_surrogate);
 
     // Feed hex digits to the shared collector
     for &hex_digit in hex_slice {

--- a/picojson/src/parse_error.rs
+++ b/picojson/src/parse_error.rs
@@ -11,10 +11,12 @@ use crate::ujson;
 pub enum ParseError {
     /// An error bubbled up from the underlying tokenizer.
     TokenizerError(ujson::Error),
-    /// The provided scratch buffer was not large enough for an operation.
+    /// The scratch buffer is full.
     ScratchBufferFull,
-    /// A string slice was not valid UTF-8.
+    /// A UTF-8 error occurred.
     InvalidUtf8(core::str::Utf8Error),
+    /// The input buffer is full.
+    InputBufferFull,
     /// A number string could not be parsed.
     InvalidNumber,
     /// The parser entered an unexpected internal state.
@@ -70,6 +72,12 @@ impl From<core::str::Utf8Error> for ParseError {
 impl From<UnexpectedState> for ParseError {
     fn from(info: UnexpectedState) -> Self {
         ParseError::Unexpected(info)
+    }
+}
+
+impl From<ujson::Error> for ParseError {
+    fn from(err: ujson::Error) -> Self {
+        ParseError::TokenizerError(err)
     }
 }
 

--- a/picojson/src/slice_content_builder.rs
+++ b/picojson/src/slice_content_builder.rs
@@ -5,7 +5,7 @@
 use crate::copy_on_escape::CopyOnEscape;
 use crate::escape_processor::{self, UnicodeEscapeCollector};
 use crate::event_processor::ContentExtractor;
-use crate::shared::{ContentRange, State};
+use crate::shared::{ContentRange, DataSource, State};
 use crate::slice_input_buffer::{InputBuffer, SliceInputBuffer};
 use crate::{Event, JsonNumber, ParseError};
 
@@ -68,42 +68,45 @@ impl ContentExtractor for SliceContentBuilder<'_, '_> {
         &mut self.unicode_escape_collector
     }
 
-    fn extract_string_content(&mut self, _start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
-        let end_pos = ContentRange::end_position_excluding_delimiter(self.buffer.current_pos());
-        let value_result = self.copy_on_escape.end_string(end_pos)?;
-        Ok(Event::String(value_result))
+    fn extract_string_content(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
+        // SliceParser-specific: Complete CopyOnEscape processing for unescaped content
+        let current_pos = self.current_position();
+        if self.has_unescaped_content() {
+            let end_pos = ContentRange::end_position_excluding_delimiter(current_pos);
+            self.copy_on_escape.end_string(end_pos)?; // Complete the CopyOnEscape processing
+        }
+
+        // Use the unified helper function to get the content
+        let content_piece = crate::shared::get_content_piece(self, start_pos, current_pos)?;
+        Ok(Event::String(content_piece.into_string()?))
     }
 
-    fn extract_key_content(&mut self, _start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
-        let end_pos = ContentRange::end_position_excluding_delimiter(self.buffer.current_pos());
-        let key_result = self.copy_on_escape.end_string(end_pos)?;
-        Ok(Event::Key(key_result))
+    fn extract_key_content(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
+        // SliceParser-specific: Complete CopyOnEscape processing for unescaped content
+        let current_pos = self.current_position();
+        if self.has_unescaped_content() {
+            let end_pos = ContentRange::end_position_excluding_delimiter(current_pos);
+            self.copy_on_escape.end_string(end_pos)?; // Complete the CopyOnEscape processing
+        }
+
+        // Use the unified helper function to get the content
+        let content_piece = crate::shared::get_content_piece(self, start_pos, current_pos)?;
+        Ok(Event::Key(content_piece.into_string()?))
     }
 
     fn extract_number(
         &mut self,
         start_pos: usize,
-        from_container_end: bool,
+        _from_container_end: bool,
         _finished: bool,
     ) -> Result<Event<'_, '_>, ParseError> {
-        // For SliceParser, use buffer-based document end detection
-        // The finished parameter should always be true for complete slices, but we don't rely on it
-        let at_document_end = self.buffer.current_pos() >= self.buffer.data_len();
-        let current_pos = self.buffer.current_pos();
-        let use_full_span = !from_container_end && at_document_end;
+        // The delimiter has already been consumed by the time this is called,
+        // so current_position is one byte past the end of the number.
+        let end_pos = ContentRange::end_position_excluding_delimiter(self.current_position());
 
-        let end_pos = if use_full_span {
-            // Standalone number: clamp to buffer length to prevent slice bounds errors
-            core::cmp::min(current_pos, self.buffer.data_len())
-        } else {
-            // Container number: exclude delimiter
-            current_pos.saturating_sub(1)
-        };
+        // Use the DataSource trait method to get the number bytes
+        let number_bytes = self.get_borrowed_slice(start_pos, end_pos)?;
 
-        let number_bytes = self
-            .buffer
-            .slice(start_pos, end_pos)
-            .map_err(|_| ParseError::InvalidNumber)?;
         let json_number = JsonNumber::from_slice(number_bytes)?;
         Ok(Event::Number(json_number))
     }
@@ -118,17 +121,20 @@ impl ContentExtractor for SliceContentBuilder<'_, '_> {
 
     fn process_unicode_escape_with_collector(&mut self) -> Result<(), ParseError> {
         let current_pos = self.buffer.current_pos();
-        let hex_slice_provider = |start, end| self.buffer.slice(start, end).map_err(Into::into);
 
         // Shared Unicode escape processing pattern
         let had_pending_high_surrogate = self.unicode_escape_collector.has_pending_high_surrogate();
+        let pending_surrogate = self.unicode_escape_collector.get_pending_high_surrogate();
 
-        let (utf8_bytes_result, escape_start_pos) =
+        let (utf8_bytes_result, escape_start_pos, new_pending_surrogate) =
             escape_processor::process_unicode_escape_sequence(
                 current_pos,
-                &mut self.unicode_escape_collector,
-                hex_slice_provider,
+                pending_surrogate,
+                self, // Pass self as the DataSource
             )?;
+
+        self.unicode_escape_collector
+            .set_pending_high_surrogate(new_pending_surrogate);
 
         // Handle UTF-8 bytes if we have them (not a high surrogate waiting for low surrogate)
         if let Some((utf8_bytes, len)) = utf8_bytes_result {
@@ -160,5 +166,32 @@ impl ContentExtractor for SliceContentBuilder<'_, '_> {
 
     fn begin_escape_sequence(&mut self) -> Result<(), ParseError> {
         Ok(())
+    }
+}
+
+/// DataSource implementation for SliceContentBuilder
+///
+/// This implementation provides access to both borrowed content from the original
+/// input slice and unescaped content from the CopyOnEscape scratch buffer.
+impl<'a, 'b> DataSource<'a, 'b> for SliceContentBuilder<'a, 'b> {
+    fn get_borrowed_slice(&'a self, start: usize, end: usize) -> Result<&'a [u8], ParseError> {
+        self.buffer.slice(start, end).map_err(Into::into)
+    }
+
+    fn get_unescaped_slice(&'b self) -> Result<&'b [u8], ParseError> {
+        // Access the scratch buffer directly with the correct lifetime
+        if !self.copy_on_escape.has_unescaped_content() {
+            return Err(ParseError::Unexpected(
+                crate::shared::UnexpectedState::StateMismatch,
+            ));
+        }
+
+        // Use the new method with proper lifetime annotation
+        let (start, end) = self.copy_on_escape.get_scratch_range();
+        self.copy_on_escape.get_scratch_buffer_slice(start, end)
+    }
+
+    fn has_unescaped_content(&self) -> bool {
+        self.copy_on_escape.has_unescaped_content()
     }
 }

--- a/picojson/src/slice_content_builder.rs
+++ b/picojson/src/slice_content_builder.rs
@@ -186,9 +186,7 @@ impl<'a, 'b> DataSource<'a, 'b> for SliceContentBuilder<'a, 'b> {
             ));
         }
 
-        // Use the new method with proper lifetime annotation
-        let (start, end) = self.copy_on_escape.get_scratch_range();
-        self.copy_on_escape.get_scratch_buffer_slice(start, end)
+        self.copy_on_escape.get_scratch_contents()
     }
 
     fn has_unescaped_content(&self) -> bool {

--- a/picojson/src/slice_input_buffer.rs
+++ b/picojson/src/slice_input_buffer.rs
@@ -52,11 +52,6 @@ impl<'a> SliceInputBuffer<'a> {
     pub fn slice(&self, start: usize, end: usize) -> Result<&'a [u8], Error> {
         self.data.get(start..end).ok_or(Error::InvalidSliceBounds)
     }
-
-    /// Gets the length of the underlying data for bounds checking.
-    pub fn data_len(&self) -> usize {
-        self.data.len()
-    }
 }
 
 #[cfg(test)]

--- a/picojson/src/stream_parser.rs
+++ b/picojson/src/stream_parser.rs
@@ -1078,10 +1078,11 @@ mod tests {
 
     #[test]
     fn test_minimal_buffer_simple_escape_1() {
-        // Buffer size 4 - clearly not enough
+        // Buffer size 4 - token "hello\\" (8 bytes) too large for buffer (4 bytes)
+        // This should be InputBufferFull, not ScratchBufferFull
         assert!(matches!(
             test_simple_escape_with_buffer_size(4),
-            Err(ParseError::ScratchBufferFull)
+            Err(ParseError::InputBufferFull)
         ));
     }
 

--- a/picojson/src/stream_parser.rs
+++ b/picojson/src/stream_parser.rs
@@ -1079,7 +1079,6 @@ mod tests {
     #[test]
     fn test_minimal_buffer_simple_escape_1() {
         // Buffer size 4 - token "hello\\" (8 bytes) too large for buffer (4 bytes)
-        // This should be InputBufferFull, not ScratchBufferFull
         assert!(matches!(
             test_simple_escape_with_buffer_size(4),
             Err(ParseError::InputBufferFull)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a generic DataSource abstraction to unify content extraction across stream and slice parsers, refactor escape and content handling to use this trait, and improve error categorization and event processing behavior.

New Features:
- Add DataSource trait with get_borrowed_slice, get_unescaped_slice, and has_unescaped_content methods
- Implement DataSource for StreamContentBuilder and SliceContentBuilder
- Introduce ContentPiece enum and get_content_piece helper to unify string/key extraction

Bug Fixes:
- Differentiate buffer-errors by replacing ScratchBufferFull with InputBufferFull for input-buffer overflow cases
- Update minimal-buffer test to expect InputBufferFull

Enhancements:
- Refactor extract_string_content, extract_key_content, and extract_number to use DataSource and ContentPiece
- Update process_unicode_escape_sequence and escape_processor API to accept DataSource and return updated surrogate state
- Add next_event_impl overload and flag to control byte accumulation during escape sequences in ParserCore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified content extraction interface, allowing consistent access to both borrowed and unescaped content via a new trait.
  * Added new methods and types to better manage and extract string, key, and number content, including improved Unicode escape handling.
  * Enhanced error reporting with a new error variant for input buffer limits.

* **Bug Fixes**
  * Improved handling of edge cases in content extraction, such as when content start exceeds end positions.
  * Clarified error types and test expectations for buffer overflows.

* **Refactor**
  * Streamlined and unified content extraction logic across different builders.
  * Replaced closure-based slice access with trait-based abstraction for improved modularity and maintainability.
  * Updated method signatures and removed redundant helper methods for cleaner interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->