### PR TITLE
Simplify and unify code

### DIFF
--- a/picojson/src/push_content_builder.rs
+++ b/picojson/src/push_content_builder.rs
@@ -6,7 +6,7 @@ use crate::escape_processor::UnicodeEscapeCollector;
 use crate::event_processor::ContentExtractor;
 use crate::shared::{DataSource, State};
 use crate::stream_buffer::StreamBuffer;
-use crate::{Event, JsonNumber, ParseError, String};
+use crate::{Event, JsonNumber, ParseError};
 
 /// A trait for handling events from a SAX-style push parser.
 ///
@@ -21,7 +21,7 @@ pub trait PushParserHandler<'input, 'scratch, E> {
 }
 
 /// Content extractor for PushParser.
-pub struct PushContentExtractor<'input, 'scratch> {
+pub struct PushContentBuilder<'input, 'scratch> {
     /// StreamBuffer for single-buffer input and escape processing
     stream_buffer: StreamBuffer<'scratch>,
     /// Parser state tracking
@@ -48,8 +48,8 @@ pub struct PushContentExtractor<'input, 'scratch> {
     in_simple_escape: bool,
 }
 
-impl<'input, 'scratch> PushContentExtractor<'input, 'scratch> {
-    /// Create a new PushContentExtractor
+impl<'input, 'scratch> PushContentBuilder<'input, 'scratch> {
+    /// Create a new PushContentBuilder
     pub fn new(buffer: &'scratch mut [u8]) -> Self {
         Self {
             stream_buffer: StreamBuffer::new(buffer),
@@ -94,10 +94,15 @@ impl<'input, 'scratch> PushContentExtractor<'input, 'scratch> {
     /// Apply queued unescaped content reset if needed
     pub fn apply_unescaped_reset_if_queued(&mut self) {
         if self.unescaped_reset_queued {
-            self.stream_buffer.clear_unescaped();
             self.unescaped_reset_queued = false;
             self.using_unescaped_buffer = false; // Always reset the flag when buffer is cleared
+            self.stream_buffer.clear_unescaped();
         }
+    }
+
+    /// Queue a reset of unescaped content for the next operation
+    fn queue_unescaped_reset(&mut self) {
+        self.unescaped_reset_queued = true;
     }
 
     /// Handle byte accumulation with selective logic based on current state
@@ -132,16 +137,9 @@ impl<'input, 'scratch> PushContentExtractor<'input, 'scratch> {
                 self.in_unicode_escape = false;
             }
         } else if self.in_simple_escape {
-            // Check if this is the start of a Unicode escape (\uXXXX)
-            if byte == b'u' {
-                // This is a Unicode escape - do NOT accumulate the 'u', let the escape processor handle it
-                self.in_simple_escape = false;
-                return Ok(()); // Skip accumulation for 'u' in Unicode escapes
-            } else {
-                // This is a simple escape - skip the raw escape character
-                self.in_simple_escape = false;
-                return Ok(());
-            }
+            // This is a Unicode escape - do NOT accumulate the 'u', let the escape processor handle it
+            self.in_simple_escape = false;
+            return Ok(()); // Skip accumulation for 'u' in Unicode escapes
         }
 
         // Regular byte accumulation logic for non-hex digits or when not in Unicode escape
@@ -160,12 +158,12 @@ impl<'input, 'scratch> PushContentExtractor<'input, 'scratch> {
                     // Don't accumulate closing quotes - they mark end of string
                     false
                 } else {
-                    self.using_unescaped_buffer
+                    self.has_unescaped_content()
                 }
             }
             State::Number(_) => {
                 // We're in number context - accumulate if using unescaped buffer (for numbers spanning chunks)
-                self.using_unescaped_buffer
+                self.has_unescaped_content()
             }
             _ => false, // Not in string/key/number context - don't accumulate
         };
@@ -176,14 +174,9 @@ impl<'input, 'scratch> PushContentExtractor<'input, 'scratch> {
 
         Ok(())
     }
-
-    /// Queue a reset of unescaped content for the next operation
-    fn queue_unescaped_reset(&mut self) {
-        self.unescaped_reset_queued = true;
-    }
 }
 
-impl ContentExtractor for PushContentExtractor<'_, '_> {
+impl ContentExtractor for PushContentBuilder<'_, '_> {
     fn next_byte(&mut self) -> Result<Option<u8>, ParseError> {
         if self.chunk_cursor < self.current_chunk.len() {
             let byte = self.current_chunk[self.chunk_cursor];
@@ -193,16 +186,6 @@ impl ContentExtractor for PushContentExtractor<'_, '_> {
         } else {
             Ok(None)
         }
-    }
-
-    fn current_position(&self) -> usize {
-        self.current_position
-    }
-
-    fn begin_string_content(&mut self, pos: usize) {
-        self.token_start_pos = pos;
-        self.using_unescaped_buffer = false;
-        self.stream_buffer.clear_unescaped();
     }
 
     fn parser_state_mut(&mut self) -> &mut State {
@@ -217,36 +200,38 @@ impl ContentExtractor for PushContentExtractor<'_, '_> {
         &mut self.unicode_escape_collector
     }
 
+    fn current_position(&self) -> usize {
+        self.current_position
+    }
+
+    fn begin_string_content(&mut self, pos: usize) {
+        self.token_start_pos = pos;
+        self.stream_buffer.clear_unescaped();
+    }
+
     fn extract_string_content(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
-        if self.using_unescaped_buffer {
-            // We have unescaped content - use it
+        // Queue reset if using unescaped content (same as the old manual path)
+        if self.has_unescaped_content() {
             self.queue_unescaped_reset();
-            let content_slice = self.get_unescaped_slice()?;
-            let content_str = core::str::from_utf8(content_slice)?;
-            Ok(Event::String(String::Unescaped(content_str)))
-        } else {
-            // No escapes - use borrowed content
-            // PushParser: current_position points AT the closing quote, but get_content_piece expects
-            // position AFTER the closing quote, so add 1
-            let content_piece =
-                crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
-            content_piece.into_string().map(Event::String)
         }
+
+        // PushParser: current_position points AT the closing quote, but get_content_piece expects
+        // position AFTER the closing quote, so add 1
+        let content_piece =
+            crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
+        content_piece.into_string().map(Event::String)
     }
 
     fn extract_key_content(&mut self, start_pos: usize) -> Result<Event<'_, '_>, ParseError> {
-        if self.using_unescaped_buffer {
-            // Content is in scratch buffer - get the complete token from there
+        // Queue reset if using unescaped content (same as the old manual path)
+        if self.has_unescaped_content() {
             self.queue_unescaped_reset();
-            let content_slice = self.get_unescaped_slice()?;
-            let content_str = core::str::from_utf8(content_slice)?;
-            Ok(Event::Key(String::Unescaped(content_str)))
-        } else {
-            // The entire token was contained in the current chunk - use direct extraction
-            let content_piece =
-                crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
-            content_piece.into_string().map(Event::Key)
         }
+
+        // The entire token was contained in the current chunk - use direct extraction
+        let content_piece =
+            crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
+        content_piece.into_string().map(Event::Key)
     }
 
     fn extract_number(
@@ -255,75 +240,27 @@ impl ContentExtractor for PushContentExtractor<'_, '_> {
         _from_container_end: bool,
         _finished: bool,
     ) -> Result<Event<'_, '_>, ParseError> {
-        let number_bytes = if self.using_unescaped_buffer {
-            // Content is in scratch buffer - get the complete token from there
+        // Queue reset if using unescaped content (same as the old manual path)
+        if self.has_unescaped_content() {
             self.queue_unescaped_reset();
-            self.get_unescaped_slice()?
-        } else {
-            // The entire token was contained in the current chunk - use direct extraction
-            let content_piece =
-                crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
-            content_piece.as_bytes()
-        };
+        }
 
+        let content_piece =
+            crate::shared::get_content_piece(self, start_pos + 1, self.current_position + 1)?;
+        let number_bytes = content_piece.as_bytes();
         let json_number = JsonNumber::from_slice(number_bytes)?;
         Ok(Event::Number(json_number))
     }
 
-    fn process_unicode_escape_with_collector(&mut self) -> Result<(), ParseError> {
-        // With the selective accumulation approach, Unicode escape processing should have
-        // already happened during byte accumulation via handle_byte_accumulation().
-        // This method is called at the end of a Unicode escape sequence by the event processor.
-        // If the collector still has incomplete data, it means we're dealing with chunked input
-        // where hex digits span chunk boundaries, OR we have a bug where hex digits aren't
-        // being fed properly.
-        Ok(())
-    }
-
-    fn handle_simple_escape_char(&mut self, escape_char: u8) -> Result<(), ParseError> {
-        // Now we know this is definitely a simple escape, not Unicode
-        self.in_simple_escape = false; // Reset flag since we're processing it now
-
-        if self.using_unescaped_buffer {
-            self.stream_buffer
-                .append_unescaped_byte(escape_char)
-                .map_err(ParseError::from)
-        } else {
-            // This shouldn't happen if begin_escape_sequence was called properly
-            Err(ParseError::Unexpected(
-                crate::shared::UnexpectedState::StateMismatch,
-            ))
-        }
-    }
-
     fn begin_escape_sequence(&mut self) -> Result<(), ParseError> {
         // Implement copy-on-escape: copy the clean part before the escape to unescaped buffer
-        if !self.using_unescaped_buffer {
+        if !self.has_unescaped_content() {
             if let State::String(start_pos) | State::Key(start_pos) = self.parser_state {
                 // start_pos points to the opening quote, so content starts at start_pos + 1
-                let content_start = start_pos + 1;
                 // Current position is where the escape character (\) is located
                 // We want to copy content up to (but not including) the escape character
-                let content_end = self.current_position;
-
                 // Copy the clean part to the unescaped buffer
-                if content_end > content_start {
-                    // Convert absolute positions to relative positions within the current data chunk
-                    let slice_start = content_start.saturating_sub(self.position_offset);
-                    let slice_end = content_end.saturating_sub(self.position_offset);
-
-                    if slice_end <= self.current_chunk.len() && slice_start <= slice_end {
-                        let clean_slice = &self.current_chunk[slice_start..slice_end];
-
-                        for &byte in clean_slice {
-                            self.stream_buffer.append_unescaped_byte(byte)?;
-                        }
-                    } else {
-                        return Err(ParseError::Unexpected(
-                            crate::shared::UnexpectedState::InvalidSliceBounds,
-                        ));
-                    }
-                }
+                self.copy_content_chunk_to_scratch(start_pos + 1, self.current_position)?;
 
                 // Mark that we're now using the unescaped buffer
                 self.using_unescaped_buffer = true;
@@ -347,7 +284,7 @@ impl ContentExtractor for PushContentExtractor<'_, '_> {
         // CRITICAL: The tokenizer processes \u and the first hex digit before emitting Begin(UnicodeEscape)
         // Since we no longer accumulate the 'u' character, we only need to handle the first hex digit
         // that was accumulated before this event arrived
-        if self.using_unescaped_buffer {
+        if self.has_unescaped_content() {
             // Get current buffer content and check if it ends with a hex digit (the first one)
             if let Ok(current_content) = self.stream_buffer.get_unescaped_slice() {
                 if !current_content.is_empty() {
@@ -377,9 +314,82 @@ impl ContentExtractor for PushContentExtractor<'_, '_> {
 
         Ok(())
     }
+
+    fn handle_simple_escape_char(&mut self, escape_char: u8) -> Result<(), ParseError> {
+        // Now we know this is definitely a simple escape, not Unicode
+        self.in_simple_escape = false; // Reset flag since we're processing it now
+
+        if self.has_unescaped_content() {
+            self.stream_buffer
+                .append_unescaped_byte(escape_char)
+                .map_err(ParseError::from)
+        } else {
+            // This shouldn't happen if begin_escape_sequence was called properly
+            Err(ParseError::Unexpected(
+                crate::shared::UnexpectedState::StateMismatch,
+            ))
+        }
+    }
+
+    fn process_unicode_escape_with_collector(&mut self) -> Result<(), ParseError> {
+        // With the selective accumulation approach, Unicode escape processing should have
+        // already happened during byte accumulation via handle_byte_accumulation().
+        // This method is called at the end of a Unicode escape sequence by the event processor.
+        // If the collector still has incomplete data, it means we're dealing with chunked input
+        // where hex digits span chunk boundaries, OR we have a bug where hex digits aren't
+        // being fed properly.
+        Ok(())
+    }
 }
 
-impl<'input, 'scratch> DataSource<'input, 'scratch> for PushContentExtractor<'input, 'scratch> {
+impl PushContentBuilder<'_, '_> {
+    /// Copy content from current chunk to scratch buffer based on current parser state
+    fn copy_content_chunk_to_scratch(
+        &mut self,
+        content_start: usize,
+        content_end: usize,
+    ) -> Result<(), ParseError> {
+        if content_end > content_start {
+            // Convert absolute positions to relative positions within the current data chunk
+            let slice_start = content_start.saturating_sub(self.position_offset);
+            let slice_end = content_end.saturating_sub(self.position_offset);
+
+            if slice_end <= self.current_chunk.len() && slice_start < slice_end {
+                let partial_slice = &self.current_chunk[slice_start..slice_end];
+
+                for &byte in partial_slice {
+                    self.stream_buffer.append_unescaped_byte(byte)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Copy partial content from current chunk to scratch buffer when chunk boundary reached
+    pub fn copy_partial_content_to_scratch(&mut self) -> Result<(), ParseError> {
+        // Determine the start of the current token content based on parser state
+        let content_start = match self.parser_state {
+            State::String(start_pos) | State::Key(start_pos) => {
+                // For strings and keys, content starts after the opening quote
+                start_pos + 1
+            }
+            State::Number(start_pos) => {
+                // For numbers, start_pos points to the character before the first digit
+                // so we need to add 1 to get to the actual number content
+                start_pos + 1
+            }
+            _ => {
+                return Ok(());
+            }
+        };
+
+        // The end is the current position (where we are in the chunk)
+        // Copy the slice of partial content from the current chunk using the common method
+        self.copy_content_chunk_to_scratch(content_start, self.current_position + 1)
+    }
+}
+
+impl<'input, 'scratch> DataSource<'input, 'scratch> for PushContentBuilder<'input, 'scratch> {
     fn get_borrowed_slice(
         &'input self,
         start: usize,
@@ -411,53 +421,6 @@ impl<'input, 'scratch> DataSource<'input, 'scratch> for PushContentExtractor<'in
     }
 
     fn has_unescaped_content(&self) -> bool {
-        self.using_unescaped_buffer
-    }
-}
-
-impl PushContentExtractor<'_, '_> {
-    /// Copy partial content from current chunk to scratch buffer when chunk boundary reached
-    pub fn copy_partial_content_to_scratch(&mut self) -> Result<(), ParseError> {
-        // Determine the start of the current token content based on parser state
-        let content_start = match self.parser_state {
-            State::String(start_pos) | State::Key(start_pos) => {
-                // For strings and keys, content starts after the opening quote
-                start_pos + 1
-            }
-            State::Number(start_pos) => {
-                // For numbers, start_pos points to the character before the first digit
-                // so we need to add 1 to get to the actual number content
-                start_pos + 1
-            }
-            _ => {
-                return Ok(());
-            }
-        };
-
-        // The end is the current position (where we are in the chunk)
-        let content_end = self.current_position + 1;
-
-        // Copy the slice of partial content from the current chunk
-        if content_end > content_start {
-            // Get the range within the current chunk
-            let slice_start = content_start.saturating_sub(self.position_offset);
-            let slice_end = content_end.saturating_sub(self.position_offset);
-
-            if slice_end <= self.current_chunk.len() && slice_start < slice_end {
-                let partial_slice = &self.current_chunk[slice_start..slice_end];
-
-                // Copy these bytes directly into the stream_buffer (the scratch space)
-                for &byte in partial_slice {
-                    self.stream_buffer
-                        .append_unescaped_byte(byte)
-                        .map_err(ParseError::from)?;
-                }
-
-                // Activate scratch buffer mode so subsequent content is also appended
-                self.using_unescaped_buffer = true;
-            }
-        }
-
-        Ok(())
+        self.stream_buffer.has_unescaped_content() || self.using_unescaped_buffer
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor and unify content builder implementations across Push, Stream, and Slice parsers by renaming types, consolidating escape handling, and extracting shared logic into helper methods.

Enhancements:
- Rename PushContentExtractor to PushContentBuilder and update references in push_parser
- Extract common reset and copying logic into helper methods (queue_unescaped_reset, copy_content_chunk_to_scratch)
- Simplify byte accumulation and escape sequence handling by removing duplicated branches
- Align and harmonize trait implementations across StreamContentBuilder and SliceContentBuilder, adding missing methods and unifying lifetimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed and reorganized internal structures for improved clarity and encapsulation.
  * Unified and simplified the handling of escape sequences and unescaped content across content builders.
  * Improved method organization and naming for better maintainability.
  * Updated internal accessors and lifetimes for consistency.

* **New Features**
  * Added new accessor methods for parser state and Unicode escape handling in content builders.

* **Bug Fixes**
  * Enhanced accuracy in detecting and managing unescaped content during parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->